### PR TITLE
Typos in CIFAR10 examples

### DIFF
--- a/examples/cifar10/cifar10_env.py
+++ b/examples/cifar10/cifar10_env.py
@@ -11,7 +11,7 @@ from time     import time as t
 parser = argparse.ArgumentParser()
 parser.add_argument('--seed', type=int, default=0)
 parser.add_argument('--n_neurons', type=int, default=100)
-parser.add_argument('--n_train', type=int, default=60000)
+parser.add_argument('--n_train', type=int, default=50000)
 parser.add_argument('--n_test', type=int, default=10000)
 parser.add_argument('--exc', type=float, default=22.5)
 parser.add_argument('--inh', type=float, default=17.5)

--- a/examples/cifar10/minimal_cifar10.py
+++ b/examples/cifar10/minimal_cifar10.py
@@ -25,6 +25,6 @@ pipeline = Pipeline(network=network,
                     plot_interval=1)
 
 # Train the network.
-for i in range(60000):    
+for i in range(50000):
     pipeline.step()
     network._reset()

--- a/examples/cifar10/minimal_supervised_cifar10.py
+++ b/examples/cifar10/minimal_supervised_cifar10.py
@@ -29,7 +29,7 @@ pipeline = Pipeline(network=network,
 
 # Train the network.
 labels = environment.labels
-for i in range(60000):
+for i in range(50000):
     # Choose an output neuron to clamp to spiking behavior.
     c = choice(10, size=1, replace=False)
     clamp = {'Ae' : 10 * labels[i].long() + Tensor(c).long()}

--- a/examples/cifar10/rank_order_cifar10.py
+++ b/examples/cifar10/rank_order_cifar10.py
@@ -11,7 +11,7 @@ from time     import time as t
 parser = argparse.ArgumentParser()
 parser.add_argument('--seed', type=int, default=0)
 parser.add_argument('--n_neurons', type=int, default=100)
-parser.add_argument('--n_train', type=int, default=60000)
+parser.add_argument('--n_train', type=int, default=50000)
 parser.add_argument('--n_test', type=int, default=10000)
 parser.add_argument('--exc', type=float, default=22.5)
 parser.add_argument('--inh', type=float, default=17.5)

--- a/examples/cifar10/supervised_cifar10.py
+++ b/examples/cifar10/supervised_cifar10.py
@@ -11,7 +11,7 @@ from time     import time as t
 parser = argparse.ArgumentParser()
 parser.add_argument('--seed', type=int, default=0)
 parser.add_argument('--n_neurons', type=int, default=100)
-parser.add_argument('--n_train', type=int, default=60000)
+parser.add_argument('--n_train', type=int, default=50000)
 parser.add_argument('--n_test', type=int, default=10000)
 parser.add_argument('--n_clamp', type=int, default=1)
 parser.add_argument('--exc', type=float, default=22.5)


### PR DESCRIPTION
should be 50000, maybe mistake from copy-pasting MNIST