### PR TITLE
Adding weight masking option.

### DIFF
--- a/bindsnet/network/__init__.py
+++ b/bindsnet/network/__init__.py
@@ -195,6 +195,8 @@ class Network:
 
                 | :code:`clamps` (:code:`dict`): Mapping of layer names to neurons which to "clamp" to spiking.
                 | :code:`reward` (:code:`float`): Scalar value used in reward-modulated learning.
+                | :code:`masks` (:code:`dict`): Mapping of connection names to boolean
+                    masks determining which weights to clamp to zero.
         
         **Example:**
     

--- a/bindsnet/network/__init__.py
+++ b/bindsnet/network/__init__.py
@@ -228,6 +228,7 @@ class Network:
         # Parse keyword arguments.
         clamps = kwargs.get('clamp', {})
         reward = kwargs.get('reward', None)
+        masks = kwargs.get('masks', {})
         
         # Effective number of timesteps
         timesteps = int(time / self.dt)
@@ -251,7 +252,8 @@ class Network:
 
             # Run synapse updates.
             for c in self.connections:
-                self.connections[c].update(reward=reward)
+                self.connections[c].update(reward=reward,
+                                           mask=masks.get(c, None))
 
             # Get input to all layers.
             inpts.update(self.get_inputs())

--- a/bindsnet/network/topology.py
+++ b/bindsnet/network/topology.py
@@ -72,9 +72,13 @@ class AbstractConnection(ABC):
         Compute connection's update rule.
         '''
         reward = kwargs.get('reward', None)
+        mask = kwargs.get('mask', None)
 
         if self.update_rule is not None:
             self.update_rule(self, reward=reward)
+
+        if mask is not None:
+            self.w.masked_fill_(mask, 0)
 
     @abstractmethod
     def normalize(self):


### PR DESCRIPTION
This is useful (for the time being) for locally-connected networks, because sparse `torch.Tensor`s aren't developed enough to use a `SparseConnection` for learning.