### PR TITLE
Reverting to old plotting spikes function

### DIFF
--- a/bindsnet/analysis/plotting.py
+++ b/bindsnet/analysis/plotting.py
@@ -74,14 +74,14 @@ def plot_spikes(network: Optional[Network] = None, spikes: Optional[Dict[str, to
     n_subplots = len(spikes.keys())
     spikes = {k : v.view(-1, v.size(-1)) for (k, v) in spikes.items()}
 
-    if time is not None:
-        assert len(time) == 2, 'Need (start, stop) values for time argument'
-        assert time[0] < time[1], 'Need start < stop in time argument'
-    else:
-        # Set it for entire duration
-        for key in spikes.keys():
-            time = (0, spikes[key].shape[1])
-            break
+    #if time is not None:
+    #    assert len(time) == 2, 'Need (start, stop) values for time argument'
+    #    assert time[0] < time[1], 'Need start < stop in time argument'
+    #else:
+    #    # Set it for entire duration
+    #    for key in spikes.keys():
+    #        time = (0, spikes[key].shape[1])
+    #        break
 
     if len(n_neurons.keys()) != 0:
         assert len(n_neurons.keys()) <= n_subplots, \

--- a/bindsnet/analysis/plotting.py
+++ b/bindsnet/analysis/plotting.py
@@ -74,14 +74,14 @@ def plot_spikes(network: Optional[Network] = None, spikes: Optional[Dict[str, to
     n_subplots = len(spikes.keys())
     spikes = {k : v.view(-1, v.size(-1)) for (k, v) in spikes.items()}
 
-    #if time is not None:
-    #    assert len(time) == 2, 'Need (start, stop) values for time argument'
-    #    assert time[0] < time[1], 'Need start < stop in time argument'
-    #else:
-    #    # Set it for entire duration
-    #    for key in spikes.keys():
-    #        time = (0, spikes[key].shape[1])
-    #        break
+    if time is not None:
+        assert len(time) == 2, 'Need (start, stop) values for time argument'
+        assert time[0] < time[1], 'Need start < stop in time argument'
+    else:
+        # Set it for entire duration
+        for key in spikes.keys():
+            time = (0, spikes[key].shape[1])
+            break
 
     if len(n_neurons.keys()) != 0:
         assert len(n_neurons.keys()) <= n_subplots, \

--- a/examples/mnist/eth_mnist.py
+++ b/examples/mnist/eth_mnist.py
@@ -155,7 +155,3 @@ for i in range(n_train):
 print('Progress: %d / %d (%.4f seconds)\n' % (n_train, n_train, t() - start))
 print('Training complete.\n')
 
-print('Calculating ngram scores')
-ngram_counts = get_ngram_counts(spike_record, labels[:len(train_spikes)], 2)
-predictions = ngram(train_spikes, labels[:len(train_spikes)], ngrams, 2)
-


### PR DESCRIPTION
`plot_spikes_new` is kept around in case we wanted to work with `bindsnet.Network` objects being passed around but can be removed later if no such use arises. Not yet tested.