### PR TITLE
add missing super.forward in Adaptive nodes

### DIFF
--- a/bindsnet/network/nodes.py
+++ b/bindsnet/network/nodes.py
@@ -529,6 +529,8 @@ class AdaptiveLIFNodes(Nodes):
         if self.lbound is not None:
             self.v.masked_fill_(self.v < self.lbound, self.lbound)
 
+        super().forward(x)
+
     def reset_(self) -> None:
         # language=rst
         """


### PR DESCRIPTION
It seems that `AdaptiveLIFNodes` were missing superclass forward call.
Necessary to update traces and such.