### PR TITLE
Better scaling for reward plot + axis labels

### DIFF
--- a/bindsnet/pipeline/__init__.py
+++ b/bindsnet/pipeline/__init__.py
@@ -223,19 +223,16 @@ class Pipeline:
     def plot_reward(self) -> None:
         # language=rst
         """
-        Plot the change of accumulated reward for each episodes
+        Plot the accumulated reward for each episode.
         """
         if self.reward_im is None and self.reward_ax is None:
-            fig, self.reward_ax = plt.subplots()
+            self.reward_im, self.reward_ax = plt.subplots()
             self.reward_ax.set_title('Reward')
             self.reward_plot, = self.reward_ax.plot(self.reward_list)
         else:
-            reward_array = np.array(self.reward_list)
-            y_min = reward_array.min()
-            y_max = reward_array.max()
-            self.reward_ax.set_xlim(left=0, right=self.episode)
-            self.reward_ax.set_ylim(bottom=y_min, top=y_max)
             self.reward_plot.set_data(range(self.episode), self.reward_list)
+            self.reward_ax.relim()
+            self.reward_ax.autoscale_view()
 
     def plot_data(self) -> None:
         # language=rst

--- a/bindsnet/pipeline/__init__.py
+++ b/bindsnet/pipeline/__init__.py
@@ -227,7 +227,9 @@ class Pipeline:
         """
         if self.reward_im is None and self.reward_ax is None:
             self.reward_im, self.reward_ax = plt.subplots()
-            self.reward_ax.set_title('Reward')
+            self.reward_ax.set_title('Accumulated reward')
+            self.reward_ax.set_xlabel('Episode')
+            self.reward_ax.set_ylabel('Reward')
             self.reward_plot, = self.reward_ax.plot(self.reward_list)
         else:
             self.reward_plot.set_data(range(self.episode), self.reward_list)


### PR DESCRIPTION
In case accumulated rewards are constant for some episodes, the horizontal line is obscured since it's right at the figures edge when using `min` and `max` for `set_ylim`. Instead, we could do automatic scaling with `relim` and `autoscale_view`, which works well and leaves margins. See for example https://stackoverflow.com/questions/10984085/automatically-rescale-ylim-and-xlim-in-matplotlib. If interested, I could also add the option to plot a moving average of reward instead of the actual rewards, since those tend to be very shaky.