### PR TITLE
Make a copy of the nn.Module object for conversion

### DIFF
--- a/bindsnet/conversion/__init__.py
+++ b/bindsnet/conversion/__init__.py
@@ -5,6 +5,7 @@ import torch.nn.functional as F
 
 from torch.nn.modules.utils import _pair
 
+from copy import deepcopy
 from time import time as t
 from typing import Union, Sequence, Optional, Tuple, Dict
 
@@ -483,6 +484,8 @@ def ann_to_snn(ann: Union[nn.Module, str], input_shape: Sequence[int], data: Opt
     """
     if isinstance(ann, str):
         ann = torch.load(ann)
+    else:
+        ann = deepcopy(ann)
 
     assert isinstance(ann, nn.Module)
 

--- a/bindsnet/conversion/__init__.py
+++ b/bindsnet/conversion/__init__.py
@@ -488,7 +488,10 @@ def ann_to_snn(ann: Union[nn.Module, str], input_shape: Sequence[int], data: Opt
 
     assert isinstance(ann, nn.Module)
 
-    if data is not None:
+    if data is None:
+        import warnings
+        warnings.warn('Data is None. ANN weights will not be scaled.', RuntimeWarning)
+    else:
         ann = data_based_normalization(
             ann=ann, data=data.detach(), percentile=percentile
         )

--- a/bindsnet/conversion/__init__.py
+++ b/bindsnet/conversion/__init__.py
@@ -6,7 +6,6 @@ import torch.nn.functional as F
 from torch.nn.modules.utils import _pair
 
 from copy import deepcopy
-from time import time as t
 from typing import Union, Sequence, Optional, Tuple, Dict
 
 import bindsnet.network.nodes as nodes
@@ -490,15 +489,9 @@ def ann_to_snn(ann: Union[nn.Module, str], input_shape: Sequence[int], data: Opt
     assert isinstance(ann, nn.Module)
 
     if data is not None:
-        print()
-        print('Example data provided. Performing data-based normalization...')
-
-        t0 = t()
         ann = data_based_normalization(
             ann=ann, data=data.detach(), percentile=percentile
         )
-
-        print(f'Elapsed: {t() - t0:.4f}')
 
     snn = Network()
 

--- a/bindsnet/conversion/__init__.py
+++ b/bindsnet/conversion/__init__.py
@@ -490,7 +490,7 @@ def ann_to_snn(ann: Union[nn.Module, str], input_shape: Sequence[int], data: Opt
 
     if data is None:
         import warnings
-        warnings.warn('Data is None. ANN weights will not be scaled.', RuntimeWarning)
+        warnings.warn('Data is None. Weights will not be scaled.', RuntimeWarning)
     else:
         ann = data_based_normalization(
             ann=ann, data=data.detach(), percentile=percentile


### PR DESCRIPTION
The conversion toolkit shouldn't modify the nn.Module object. There might be a better way to accomplish the same thing though.

I also removed the print statements for the time elapsed.