### PR TITLE
Revert exact integration and neuron decay reparametization.

### DIFF
--- a/bindsnet/models/__init__.py
+++ b/bindsnet/models/__init__.py
@@ -37,9 +37,9 @@ class TwoLayerNetwork(Network):
         self.n_neurons = n_neurons
         self.dt = dt
 
-        self.add_layer(Input(n=self.n_inpt, traces=True, trace=20.0), name='X')
+        self.add_layer(Input(n=self.n_inpt, traces=True, trace=5e-2), name='X')
         self.add_layer(LIFNodes(n=self.n_neurons, traces=True, rest=-65.0, reset=-65.0, thresh=-52.0, refrac=5,
-                                decay=100.0, trace=20.0), name='Y')
+                                decay=1e-2, trace=5e-2), name='Y')
 
         w = 0.3 * torch.rand(self.n_inpt, self.n_neurons)
         self.add_connection(Connection(source=self.layers['X'], target=self.layers['Y'], w=w, update_rule=PostPre,
@@ -81,14 +81,14 @@ class DiehlAndCook2015(Network):
         self.inh = inh
         self.dt = dt
 
-        self.add_layer(Input(n=self.n_inpt, traces=True, trace=20.0), name='X')
+        self.add_layer(Input(n=self.n_inpt, traces=True, trace=5e-2), name='X')
         self.add_layer(DiehlAndCookNodes(n=self.n_neurons, traces=True, rest=-65.0, reset=-60.0, thresh=-52.0, refrac=5,
-                                         decay=100.0, trace=20.0, theta_plus=theta_plus,
+                                         decay=1e-2, trace=5e-2, theta_plus=theta_plus,
                                          theta_decay=theta_decay),
                        name='Ae')
 
         self.add_layer(LIFNodes(n=self.n_neurons, traces=False, rest=-60.0, reset=-45.0, thresh=-40.0, decay=10.0,
-                                refrac=2, trace=20.0),
+                                refrac=2, trace=5e-2),
                        name='Ai')
 
         w = 0.3 * torch.rand(self.n_inpt, self.n_neurons)
@@ -139,12 +139,12 @@ class DiehlAndCook2015v2(Network):
         self.inh = inh
         self.dt = dt
 
-        input_layer = Input(n=self.n_inpt, traces=True, trace=20.0)
+        input_layer = Input(n=self.n_inpt, traces=True, trace=5e-2)
         self.add_layer(input_layer, name='X')
 
         output_layer = DiehlAndCookNodes(
             n=self.n_neurons, traces=True, rest=-65.0, reset=-60.0, thresh=-52.0, refrac=5,
-            decay=100.0, trace=20.0, theta_plus=theta_plus, theta_decay=theta_decay
+            decay=1e-2, trace=5e-2, theta_plus=theta_plus, theta_decay=theta_decay
         )
         self.add_layer(output_layer, name='Y')
 
@@ -196,12 +196,12 @@ class IncreasingInhibitionNetwork(Network):
         self.max_inhib = max_inhib
         self.dt = dt
 
-        input_layer = Input(n=self.n_input, traces=True, trace=20.0)
+        input_layer = Input(n=self.n_input, traces=True, trace=5e-2)
         self.add_layer(input_layer, name='X')
 
         output_layer = DiehlAndCookNodes(
             n=self.n_neurons, traces=True, rest=-65.0, reset=-60.0, thresh=-52.0, refrac=5,
-            decay=100.0, trace=20.0, theta_plus=theta_plus, theta_decay=theta_decay
+            decay=1e-2, trace=5e-2, theta_plus=theta_plus, theta_decay=theta_decay
         )
         self.add_layer(output_layer, name='Y')
 
@@ -285,13 +285,13 @@ class LocallyConnectedNetwork(Network):
                          int((input_shape[1] - kernel_size[1]) / stride[1]) + 1)
 
         if real:
-            input_layer = RealInput(n=self.n_inpt, traces=True, trace=20.0)
+            input_layer = RealInput(n=self.n_inpt, traces=True, trace=5e-2)
         else:
-            input_layer = Input(n=self.n_inpt, traces=True, trace=20.0)
+            input_layer = Input(n=self.n_inpt, traces=True, trace=5e-2)
 
         output_layer = DiehlAndCookNodes(
             n=self.n_filters * conv_size[0] * conv_size[1], traces=True, rest=-65.0, reset=-60.0,
-            thresh=-52.0, refrac=5, decay=100.0, trace=20.0, theta_plus=theta_plus, theta_decay=theta_decay
+            thresh=-52.0, refrac=5, decay=1e-2, trace=5e-2, theta_plus=theta_plus, theta_decay=theta_decay
         )
         input_output_conn = LocallyConnectedConnection(
             input_layer, output_layer, kernel_size=kernel_size, stride=stride, n_filters=n_filters,

--- a/bindsnet/models/__init__.py
+++ b/bindsnet/models/__init__.py
@@ -37,9 +37,9 @@ class TwoLayerNetwork(Network):
         self.n_neurons = n_neurons
         self.dt = dt
 
-        self.add_layer(Input(n=self.n_inpt, traces=True, tc_trace=20.0), name='X')
+        self.add_layer(Input(n=self.n_inpt, traces=True, trace=20.0), name='X')
         self.add_layer(LIFNodes(n=self.n_neurons, traces=True, rest=-65.0, reset=-65.0, thresh=-52.0, refrac=5,
-                                tc_decay=100.0, tc_trace=20.0), name='Y')
+                                decay=100.0, trace=20.0), name='Y')
 
         w = 0.3 * torch.rand(self.n_inpt, self.n_neurons)
         self.add_connection(Connection(source=self.layers['X'], target=self.layers['Y'], w=w, update_rule=PostPre,
@@ -56,7 +56,7 @@ class DiehlAndCook2015(Network):
 
     def __init__(self, n_inpt: int, n_neurons: int = 100, exc: float = 22.5, inh: float = 17.5, dt: float = 1.0,
                  nu: Optional[Union[float, Sequence[float]]] = (1e-4, 1e-2), wmin: float = 0.0, wmax: float = 1.0,
-                 norm: float = 78.4, theta_plus: float = 0.05, tc_theta_decay: float = 1e7) -> None:
+                 norm: float = 78.4, theta_plus: float = 0.05, theta_decay: float = 1e7) -> None:
         # language=rst
         """
         Constructor for class ``DiehlAndCook2015``.
@@ -71,7 +71,7 @@ class DiehlAndCook2015(Network):
         :param wmax: Maximum allowed weight on input to excitatory synapses.
         :param norm: Input to excitatory layer connection weights normalization constant.
         :param theta_plus: On-spike increment of ``DiehlAndCookNodes`` membrane threshold potential.
-        :param tc_theta_decay: Time constant of ``DiehlAndCookNodes`` threshold potential decay.
+        :param theta_decay: Time constant of ``DiehlAndCookNodes`` threshold potential decay.
         """
         super().__init__(dt=dt)
 
@@ -81,14 +81,14 @@ class DiehlAndCook2015(Network):
         self.inh = inh
         self.dt = dt
 
-        self.add_layer(Input(n=self.n_inpt, traces=True, tc_trace=20.0), name='X')
+        self.add_layer(Input(n=self.n_inpt, traces=True, trace=20.0), name='X')
         self.add_layer(DiehlAndCookNodes(n=self.n_neurons, traces=True, rest=-65.0, reset=-60.0, thresh=-52.0, refrac=5,
-                                         tc_decay=100.0, tc_trace=20.0, theta_plus=theta_plus,
-                                         tc_theta_decay=tc_theta_decay),
+                                         decay=100.0, trace=20.0, theta_plus=theta_plus,
+                                         theta_decay=theta_decay),
                        name='Ae')
 
-        self.add_layer(LIFNodes(n=self.n_neurons, traces=False, rest=-60.0, reset=-45.0, thresh=-40.0, tc_decay=10.0,
-                                refrac=2, tc_trace=20.0),
+        self.add_layer(LIFNodes(n=self.n_neurons, traces=False, rest=-60.0, reset=-45.0, thresh=-40.0, decay=10.0,
+                                refrac=2, trace=20.0),
                        name='Ai')
 
         w = 0.3 * torch.rand(self.n_inpt, self.n_neurons)
@@ -116,7 +116,7 @@ class DiehlAndCook2015v2(Network):
     def __init__(self, n_inpt: int, n_neurons: int = 100, inh: float = 17.5, dt: float = 1.0,
                  nu: Optional[Union[float, Sequence[float]]] = (1e-4, 1e-2), wmin: Optional[float] = None,
                  wmax: Optional[float] = None, norm: float = 78.4, theta_plus: float = 0.05,
-                 tc_theta_decay: float = 1e7) -> None:
+                 theta_decay: float = 1e7) -> None:
         # language=rst
         """
         Constructor for class ``DiehlAndCook2015v2``.
@@ -130,7 +130,7 @@ class DiehlAndCook2015v2(Network):
         :param wmax: Maximum allowed weight on input to excitatory synapses.
         :param norm: Input to excitatory layer connection weights normalization constant.
         :param theta_plus: On-spike increment of ``DiehlAndCookNodes`` membrane threshold potential.
-        :param tc_theta_decay: Time constant of ``DiehlAndCookNodes`` threshold potential decay.
+        :param theta_decay: Time constant of ``DiehlAndCookNodes`` threshold potential decay.
         """
         super().__init__(dt=dt)
 
@@ -139,12 +139,12 @@ class DiehlAndCook2015v2(Network):
         self.inh = inh
         self.dt = dt
 
-        input_layer = Input(n=self.n_inpt, traces=True, tc_trace=20.0)
+        input_layer = Input(n=self.n_inpt, traces=True, trace=20.0)
         self.add_layer(input_layer, name='X')
 
         output_layer = DiehlAndCookNodes(
             n=self.n_neurons, traces=True, rest=-65.0, reset=-60.0, thresh=-52.0, refrac=5,
-            tc_decay=100.0, tc_trace=20.0, theta_plus=theta_plus, tc_theta_decay=tc_theta_decay
+            decay=100.0, trace=20.0, theta_plus=theta_plus, theta_decay=theta_decay
         )
         self.add_layer(output_layer, name='Y')
 
@@ -171,7 +171,7 @@ class IncreasingInhibitionNetwork(Network):
 
     def __init__(self, n_input: int, n_neurons: int = 100, start_inhib: float = 1.0, max_inhib: float = 100.0,
                  dt: float = 1.0, nu: Optional[Union[float, Sequence[float]]] = (1e-4, 1e-2), wmin: float = 0.0,
-                 wmax: float = 1.0, norm: float = 78.4, theta_plus: float = 0.05, tc_theta_decay: float = 1e7) -> None:
+                 wmax: float = 1.0, norm: float = 78.4, theta_plus: float = 0.05, theta_decay: float = 1e7) -> None:
         # language=rst
         """
         Constructor for class ``IncreasingInhibitionNetwork``.
@@ -185,7 +185,7 @@ class IncreasingInhibitionNetwork(Network):
         :param wmax: Maximum allowed weight on input to excitatory synapses.
         :param norm: Input to excitatory layer connection weights normalization constant.
         :param theta_plus: On-spike increment of ``DiehlAndCookNodes`` membrane threshold potential.
-        :param tc_theta_decay: Time constant of ``DiehlAndCookNodes`` threshold potential decay.
+        :param theta_decay: Time constant of ``DiehlAndCookNodes`` threshold potential decay.
         """
         super().__init__(dt=dt)
 
@@ -196,12 +196,12 @@ class IncreasingInhibitionNetwork(Network):
         self.max_inhib = max_inhib
         self.dt = dt
 
-        input_layer = Input(n=self.n_input, traces=True, tc_trace=20.0)
+        input_layer = Input(n=self.n_input, traces=True, trace=20.0)
         self.add_layer(input_layer, name='X')
 
         output_layer = DiehlAndCookNodes(
             n=self.n_neurons, traces=True, rest=-65.0, reset=-60.0, thresh=-52.0, refrac=5,
-            tc_decay=100.0, tc_trace=20.0, theta_plus=theta_plus, tc_theta_decay=tc_theta_decay
+            decay=100.0, trace=20.0, theta_plus=theta_plus, theta_decay=theta_decay
         )
         self.add_layer(output_layer, name='Y')
 
@@ -238,7 +238,7 @@ class LocallyConnectedNetwork(Network):
     def __init__(self, n_inpt: int, input_shape: List[int], kernel_size: Union[int, Tuple[int, int]],
                  stride: Union[int, Tuple[int, int]], n_filters: int, inh: float = 25.0, dt: float = 1.0,
                  nu: Optional[Union[float, Sequence[float]]] = (1e-4, 1e-2), theta_plus: float = 0.05,
-                 tc_theta_decay: float = 1e7, wmin: float = 0.0, wmax: float = 1.0, norm: Optional[float] = 0.2,
+                 theta_decay: float = 1e7, wmin: float = 0.0, wmax: float = 1.0, norm: Optional[float] = 0.2,
                  real=False) -> None:
         # language=rst
         """
@@ -256,7 +256,7 @@ class LocallyConnectedNetwork(Network):
         :param wmin: Minimum allowed weight on ``Input`` to ``DiehlAndCookNodes`` synapses.
         :param wmax: Maximum allowed weight on ``Input`` to ``DiehlAndCookNodes`` synapses.
         :param theta_plus: On-spike increment of ``DiehlAndCookNodes`` membrane threshold potential.
-        :param tc_theta_decay: Time constant of ``DiehlAndCookNodes`` threshold potential decay.
+        :param theta_decay: Time constant of ``DiehlAndCookNodes`` threshold potential decay.
         :param norm: ``Input`` to ``DiehlAndCookNodes`` layer connection weights normalization constant.
         :param real: Whether to use real-valued (non-spiking) input (implemented as a "clamp").
         """
@@ -273,7 +273,7 @@ class LocallyConnectedNetwork(Network):
         self.inh = inh
         self.dt = dt
         self.theta_plus = theta_plus
-        self.tc_theta_decay = tc_theta_decay
+        self.theta_decay = theta_decay
         self.wmin = wmin
         self.wmax = wmax
         self.norm = norm
@@ -285,13 +285,13 @@ class LocallyConnectedNetwork(Network):
                          int((input_shape[1] - kernel_size[1]) / stride[1]) + 1)
 
         if real:
-            input_layer = RealInput(n=self.n_inpt, traces=True, tc_trace=20.0)
+            input_layer = RealInput(n=self.n_inpt, traces=True, trace=20.0)
         else:
-            input_layer = Input(n=self.n_inpt, traces=True, tc_trace=20.0)
+            input_layer = Input(n=self.n_inpt, traces=True, trace=20.0)
 
         output_layer = DiehlAndCookNodes(
             n=self.n_filters * conv_size[0] * conv_size[1], traces=True, rest=-65.0, reset=-60.0,
-            thresh=-52.0, refrac=5, tc_decay=100.0, tc_trace=20.0, theta_plus=theta_plus, tc_theta_decay=tc_theta_decay
+            thresh=-52.0, refrac=5, decay=100.0, trace=20.0, theta_plus=theta_plus, theta_decay=theta_decay
         )
         input_output_conn = LocallyConnectedConnection(
             input_layer, output_layer, kernel_size=kernel_size, stride=stride, n_filters=n_filters,

--- a/bindsnet/network/nodes.py
+++ b/bindsnet/network/nodes.py
@@ -13,7 +13,7 @@ class Nodes(ABC):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False) -> None:
+                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False) -> None:
         # language=rst
         """
         Abstract base class constructor.
@@ -21,7 +21,7 @@ class Nodes(ABC):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record decaying spike traces.
-        :param tc_trace: Time constant of spike trace decay.
+        :param trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         """
         super().__init__()
@@ -46,7 +46,7 @@ class Nodes(ABC):
 
         if self.traces:
             self.x = torch.zeros(self.shape)  # Firing traces.
-            self.tc_trace = torch.tensor(tc_trace)  # Time constant of spike trace decay.
+            self.trace = torch.tensor(trace)  # Time constant of spike trace decay.
 
         if self.sum_input:
             self.summed = torch.zeros(self.shape)  # Summed inputs.
@@ -64,7 +64,7 @@ class Nodes(ABC):
         """
         if self.traces:
             # Decay and set spike traces.
-            self.x *= torch.exp(-self.dt / self.tc_trace)
+            self.x *= torch.exp(-self.dt / self.trace)
             self.x.masked_fill_(self.s, 1)
 
         if self.sum_input:
@@ -103,7 +103,7 @@ class Input(Nodes, AbstractInput):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None,
-                 traces: bool = False, tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False) -> None:
+                 traces: bool = False, trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False) -> None:
         # language=rst
         """
         Instantiates a layer of input neurons.
@@ -111,10 +111,10 @@ class Input(Nodes, AbstractInput):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record decaying spike traces.
-        :param tc_trace: Time constant of spike trace decay.
+        :param trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         """
-        super().__init__(n, shape, traces, tc_trace, sum_input)
+        super().__init__(n, shape, traces, trace, sum_input)
 
     def forward(self, x: torch.Tensor) -> None:
         # language=rst
@@ -142,7 +142,7 @@ class RealInput(Nodes, AbstractInput):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False) -> None:
+                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False) -> None:
         # language=rst
         """
         Instantiates a layer of input neurons.
@@ -150,10 +150,10 @@ class RealInput(Nodes, AbstractInput):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record decaying spike traces.
-        :param tc_trace: Time constant of spike trace decay.
+        :param trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         """
-        super().__init__(n, shape, traces, tc_trace, sum_input)
+        super().__init__(n, shape, traces, trace, sum_input)
 
         self.s = self.s.float()
 
@@ -169,7 +169,7 @@ class RealInput(Nodes, AbstractInput):
 
         if self.traces:
             # Decay and set spike traces.
-            self.x *= torch.exp(-self.dt / self.tc_trace)
+            self.x *= torch.exp(-self.dt / self.trace)
             self.x.masked_fill_(self.s != 0, 1)
 
         if self.sum_input:
@@ -192,7 +192,7 @@ class McCullochPitts(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
+                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  thresh: Union[float, torch.Tensor] = 1.0) -> None:
         # language=rst
         """
@@ -201,11 +201,11 @@ class McCullochPitts(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param tc_trace: Time constant of spike trace decay.
+        :param trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param thresh: Spike threshold voltage.
         """
-        super().__init__(n, shape, traces, tc_trace, sum_input)
+        super().__init__(n, shape, traces, trace, sum_input)
 
         self.thresh = thresh  # Spike threshold voltage.
         self.v = torch.zeros(self.shape)  # Neuron voltages.
@@ -237,7 +237,7 @@ class IFNodes(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
+                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  thresh: Union[float, torch.Tensor] = -52.0, reset: Union[float, torch.Tensor] = -65.0,
                  refrac: Union[int, torch.Tensor] = 5, lbound: float = None) -> None:
         # language=rst
@@ -247,14 +247,14 @@ class IFNodes(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param tc_trace: Time constant of spike trace decay.
+        :param trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param thresh: Spike threshold voltage.
         :param reset: Post-spike reset voltage.
         :param refrac: Refractory (non-firing) period of the neuron.
         :param lbound: Lower bound of the voltage.
         """
-        super().__init__(n, shape, traces, tc_trace, sum_input)
+        super().__init__(n, shape, traces, trace, sum_input)
 
         self.reset = torch.tensor(reset)  # Post-spike reset voltage.
         self.thresh = torch.tensor(thresh)  # Spike threshold voltage.
@@ -308,10 +308,10 @@ class LIFNodes(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
+                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  thresh: Union[float, torch.Tensor] = -52.0, rest: Union[float, torch.Tensor] = -65.0,
                  reset: Union[float, torch.Tensor] = -65.0, refrac: Union[int, torch.Tensor] = 5,
-                 tc_decay: Union[float, torch.Tensor] = 100.0, lbound: float = None) -> None:
+                 decay: Union[float, torch.Tensor] = 100.0, lbound: float = None) -> None:
         # language=rst
         """
         Instantiates a layer of LIF neurons.
@@ -319,22 +319,22 @@ class LIFNodes(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param tc_trace: Time constant of spike trace decay.
+        :param trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param thresh: Spike threshold voltage.
         :param rest: Resting membrane voltage.
         :param reset: Post-spike reset voltage.
         :param refrac: Refractory (non-firing) period of the neuron.
-        :param tc_decay: Time constant of neuron voltage decay.
+        :param decay: Time constant of neuron voltage decay.
         :param lbound: Lower bound of the voltage.
         """
-        super().__init__(n, shape, traces, tc_trace, sum_input)
+        super().__init__(n, shape, traces, trace, sum_input)
 
         self.rest = torch.tensor(rest)  # Rest voltage.
         self.reset = torch.tensor(reset)  # Post-spike reset voltage.
         self.thresh = torch.tensor(thresh)  # Spike threshold voltage.
         self.refrac = torch.tensor(refrac)  # Post-spike refractory period.
-        self.tc_decay = torch.tensor(tc_decay)  # Time constant of neuron voltage decay.
+        self.decay = torch.tensor(decay)  # Time constant of neuron voltage decay.
         self.lbound = lbound  # Lower bound of voltage.
 
         self.v = self.rest * torch.ones(self.shape)  # Neuron voltages.
@@ -348,7 +348,7 @@ class LIFNodes(Nodes):
         :param x: Inputs to the layer.
         """
         # Decay voltages.
-        self.v = self.rest + torch.exp(-self.dt / self.tc_decay) * (self.v - self.rest)
+        self.v = self.rest + torch.exp(-self.dt / self.decay) * (self.v - self.rest)
 
         # Integrate inputs.
         self.v += (self.refrac_count == 0).float() * x
@@ -388,10 +388,10 @@ class CurrentLIFNodes(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
+                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  thresh: Union[float, torch.Tensor] = -52.0, rest: Union[float, torch.Tensor] = -65.0,
                  reset: Union[float, torch.Tensor] = -65.0, refrac: Union[int, torch.Tensor] = 5,
-                 tc_decay: Union[float, torch.Tensor] = 100.0, tc_i_decay: Union[float, torch.Tensor] = 2.0,
+                 decay: Union[float, torch.Tensor] = 100.0, i_decay: Union[float, torch.Tensor] = 2.0,
                  lbound: float = None) -> None:
         # language=rst
         """
@@ -399,24 +399,24 @@ class CurrentLIFNodes(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param tc_trace: Time constant of spike trace decay.
+        :param trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param thresh: Spike threshold voltage.
         :param rest: Resting membrane voltage.
         :param reset: Post-spike reset voltage.
         :param refrac: Refractory (non-firing) period of the neuron.
-        :param tc_decay: Time constant of neuron voltage decay.
-        :param tc_i_decay: Time constant of synaptic input current decay.
+        :param decay: Time constant of neuron voltage decay.
+        :param i_decay: Time constant of synaptic input current decay.
         :param lbound: Lower bound of the voltage.
         """
-        super().__init__(n, shape, traces, tc_trace, sum_input)
+        super().__init__(n, shape, traces, trace, sum_input)
 
         self.rest = torch.tensor(rest)  # Rest voltage.
         self.reset = torch.tensor(reset)  # Post-spike reset voltage.
         self.thresh = torch.tensor(thresh)  # Spike threshold voltage.
         self.refrac = torch.tensor(refrac)  # Post-spike refractory period.
-        self.tc_decay = torch.tensor(tc_decay)  # Time constant of neuron voltage decay.
-        self.tc_i_decay = torch.tensor(tc_i_decay)  # Time constant of synaptic input current decay.
+        self.decay = torch.tensor(decay)  # Time constant of neuron voltage decay.
+        self.i_decay = torch.tensor(i_decay)  # Time constant of synaptic input current decay.
         self.lbound = lbound  # Lower bound of voltage.
 
         self.v = self.rest * torch.ones(self.shape)  # Neuron voltages.
@@ -431,8 +431,8 @@ class CurrentLIFNodes(Nodes):
         :param x: Inputs to the layer.
         """
         # Decay voltages and current.
-        self.v = self.rest + torch.exp(-self.dt / self.tc_decay) * (self.v - self.rest)
-        self.i *= torch.exp(-self.dt / self.tc_i_decay)
+        self.v = self.rest + torch.exp(-self.dt / self.decay) * (self.v - self.rest)
+        self.i *= torch.exp(-self.dt / self.i_decay)
 
         # Decrement refractory counters.
         self.refrac_count = (self.refrac_count > 0).float() * (self.refrac_count - self.dt)
@@ -473,11 +473,11 @@ class AdaptiveLIFNodes(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
+                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  rest: Union[float, torch.Tensor] = -65.0, reset: Union[float, torch.Tensor] = -65.0,
                  thresh: Union[float, torch.Tensor] = -52.0, refrac: Union[int, torch.Tensor] = 5,
-                 tc_decay: Union[float, torch.Tensor] = 100.0, theta_plus: Union[float, torch.Tensor] = 0.05,
-                 tc_theta_decay: Union[float, torch.Tensor] = 1e7, lbound: float = None) -> None:
+                 decay: Union[float, torch.Tensor] = 100.0, theta_plus: Union[float, torch.Tensor] = 0.05,
+                 theta_decay: Union[float, torch.Tensor] = 1e7, lbound: float = None) -> None:
         # language=rst
         """
         Instantiates a layer of LIF neurons with adaptive firing thresholds.
@@ -485,26 +485,26 @@ class AdaptiveLIFNodes(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param tc_trace: Time constant of spike trace decay.
+        :param trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param rest: Resting membrane voltage.
         :param reset: Post-spike reset voltage.
         :param thresh: Spike threshold voltage.
         :param refrac: Refractory (non-firing) period of the neuron.
-        :param tc_decay: Time constant of neuron voltage decay.
+        :param decay: Time constant of neuron voltage decay.
         :param theta_plus: Voltage increase of threshold after spiking.
-        :param tc_theta_decay: Time constant of adaptive threshold decay.
+        :param theta_decay: Time constant of adaptive threshold decay.
         :param lbound: Lower bound of the voltage.
         """
-        super().__init__(n, shape, traces, tc_trace, sum_input)
+        super().__init__(n, shape, traces, trace, sum_input)
 
         self.rest = torch.tensor(rest)  # Rest voltage.
         self.reset = torch.tensor(reset)  # Post-spike reset voltage.
         self.thresh = torch.tensor(thresh)  # Spike threshold voltage.
         self.refrac = torch.tensor(refrac)  # Post-spike refractory period.
-        self.tc_decay = torch.tensor(tc_decay)  # Time constant of neuron voltage decay.
+        self.decay = torch.tensor(decay)  # Time constant of neuron voltage decay.
         self.theta_plus = torch.tensor(theta_plus)  # Constant threshold increase on spike.
-        self.tc_theta_decay = torch.tensor(tc_theta_decay)  # Time constant of adaptive threshold decay.
+        self.theta_decay = torch.tensor(theta_decay)  # Time constant of adaptive threshold decay.
         self.lbound = lbound  # Lower bound of voltage.
 
         self.v = self.rest * torch.ones(self.shape)  # Neuron voltages.
@@ -519,8 +519,8 @@ class AdaptiveLIFNodes(Nodes):
         :param x: Inputs to the layer.
         """
         # Decay voltages and adaptive thresholds.
-        self.v = self.rest + torch.exp(-self.dt / self.tc_decay) * (self.v - self.rest)
-        self.theta *= torch.exp(-self.dt / self.tc_theta_decay)
+        self.v = self.rest + torch.exp(-self.dt / self.decay) * (self.v - self.rest)
+        self.theta *= torch.exp(-self.dt / self.theta_decay)
 
         # Integrate inputs.
         self.v += (self.refrac_count == 0).float() * x
@@ -560,11 +560,11 @@ class DiehlAndCookNodes(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
+                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  thresh: Union[float, torch.Tensor] = -52.0, rest: Union[float, torch.Tensor] = -65.0,
                  reset: Union[float, torch.Tensor] = -65.0, refrac: Union[int, torch.Tensor] = 5,
-                 tc_decay: Union[float, torch.Tensor] = 100.0, theta_plus: Union[float, torch.Tensor] = 0.05,
-                 tc_theta_decay: Union[float, torch.Tensor] = 1e7, lbound: float = None,
+                 decay: Union[float, torch.Tensor] = 100.0, theta_plus: Union[float, torch.Tensor] = 0.05,
+                 theta_decay: Union[float, torch.Tensor] = 1e7, lbound: float = None,
                  one_spike: bool = True) -> None:
         # language=rst
         """
@@ -573,27 +573,27 @@ class DiehlAndCookNodes(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param tc_trace: Time constant of spike trace decay.
+        :param trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param thresh: Spike threshold voltage.
         :param rest: Resting membrane voltage.
         :param reset: Post-spike reset voltage.
         :param refrac: Refractory (non-firing) period of the neuron.
-        :param tc_decay: Time constant of neuron voltage decay.
+        :param decay: Time constant of neuron voltage decay.
         :param theta_plus: Voltage increase of threshold after spiking.
-        :param tc_theta_decay: Time constant of adaptive threshold decay.
+        :param theta_decay: Time constant of adaptive threshold decay.
         :param lbound: Lower bound of the voltage.
         :param one_spike: Whether to allow only one spike per timestep.
         """
-        super().__init__(n, shape, traces, tc_trace, sum_input)
+        super().__init__(n, shape, traces, trace, sum_input)
 
         self.rest = torch.tensor(rest)  # Rest voltage.
         self.reset = torch.tensor(reset)  # Post-spike reset voltage.
         self.thresh = torch.tensor(thresh)  # Spike threshold voltage.
         self.refrac = torch.tensor(refrac)  # Post-spike refractory period.
-        self.tc_decay = torch.tensor(tc_decay)  # Time constant of neuron voltage decay.
+        self.decay = torch.tensor(decay)  # Time constant of neuron voltage decay.
         self.theta_plus = torch.tensor(theta_plus)  # Constant threshold increase on spike.
-        self.theta_decay = torch.tensor(tc_theta_decay)  # Time constant of adaptive threshold decay.
+        self.theta_decay = torch.tensor(theta_decay)  # Time constant of adaptive threshold decay.
         self.lbound = lbound  # Lower bound of voltage.
         self.one_spike = one_spike  # One spike per timestep.
 
@@ -609,7 +609,7 @@ class DiehlAndCookNodes(Nodes):
         :param x: Inputs to the layer.
         """
         # Decay voltages and adaptive thresholds.
-        self.v = self.rest + torch.exp(-self.dt / self.tc_decay) * (self.v - self.rest)
+        self.v = self.rest + torch.exp(-self.dt / self.decay) * (self.v - self.rest)
         self.theta *= torch.exp(-self.dt / self.theta_decay)
 
         # Integrate inputs.
@@ -656,7 +656,7 @@ class IzhikevichNodes(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False, excitatory: float = 1,
+                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False, excitatory: float = 1,
                  thresh: Union[float, torch.Tensor] = 45.0, rest: Union[float, torch.Tensor] = -65.0,
                  lbound: float = None) -> None:
         # language=rst
@@ -666,14 +666,14 @@ class IzhikevichNodes(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param tc_trace: Time constant of spike trace decay.
+        :param trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param excitatory: Percent of excitatory (vs. inhibitory) neurons in the layer; in range ``[0, 1]``.
         :param thresh: Spike threshold voltage.
         :param rest: Resting membrane voltage.
         :param lbound: Lower bound of the voltage.
         """
-        super().__init__(n, shape, traces, tc_trace, sum_input)
+        super().__init__(n, shape, traces, trace, sum_input)
 
         self.rest = rest  # Rest voltage.
         self.thresh = thresh  # Spike threshold voltage.

--- a/bindsnet/network/nodes.py
+++ b/bindsnet/network/nodes.py
@@ -348,7 +348,7 @@ class LIFNodes(Nodes):
         :param x: Inputs to the layer.
         """
         # Decay voltages.
-        self.v = self.rest + torch.exp(-self.dt / self.decay) * (self.v - self.rest)
+        self.v -= self.dt * self.decay * (self.v - self.rest)
 
         # Integrate inputs.
         self.v += (self.refrac_count == 0).float() * x

--- a/bindsnet/network/nodes.py
+++ b/bindsnet/network/nodes.py
@@ -13,7 +13,7 @@ class Nodes(ABC):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False) -> None:
+                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False) -> None:
         # language=rst
         """
         Abstract base class constructor.
@@ -21,7 +21,7 @@ class Nodes(ABC):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record decaying spike traces.
-        :param trace: Time constant of spike trace decay.
+        :param tc_trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         """
         super().__init__()
@@ -46,7 +46,7 @@ class Nodes(ABC):
 
         if self.traces:
             self.x = torch.zeros(self.shape)  # Firing traces.
-            self.trace = torch.tensor(trace)  # Time constant of spike trace decay.
+            self.tc_trace = torch.tensor(tc_trace)  # Time constant of spike trace decay.
 
         if self.sum_input:
             self.summed = torch.zeros(self.shape)  # Summed inputs.
@@ -64,7 +64,7 @@ class Nodes(ABC):
         """
         if self.traces:
             # Decay and set spike traces.
-            self.x *= torch.exp(-self.dt / self.trace)
+            self.x *= torch.exp(-self.dt / self.tc_trace)
             self.x.masked_fill_(self.s, 1)
 
         if self.sum_input:
@@ -103,7 +103,7 @@ class Input(Nodes, AbstractInput):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None,
-                 traces: bool = False, trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False) -> None:
+                 traces: bool = False, tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False) -> None:
         # language=rst
         """
         Instantiates a layer of input neurons.
@@ -111,10 +111,10 @@ class Input(Nodes, AbstractInput):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record decaying spike traces.
-        :param trace: Time constant of spike trace decay.
+        :param tc_trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         """
-        super().__init__(n, shape, traces, trace, sum_input)
+        super().__init__(n, shape, traces, tc_trace, sum_input)
 
     def forward(self, x: torch.Tensor) -> None:
         # language=rst
@@ -142,7 +142,7 @@ class RealInput(Nodes, AbstractInput):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False) -> None:
+                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False) -> None:
         # language=rst
         """
         Instantiates a layer of input neurons.
@@ -150,10 +150,10 @@ class RealInput(Nodes, AbstractInput):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record decaying spike traces.
-        :param trace: Time constant of spike trace decay.
+        :param tc_trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         """
-        super().__init__(n, shape, traces, trace, sum_input)
+        super().__init__(n, shape, traces, tc_trace, sum_input)
 
         self.s = self.s.float()
 
@@ -169,7 +169,7 @@ class RealInput(Nodes, AbstractInput):
 
         if self.traces:
             # Decay and set spike traces.
-            self.x *= torch.exp(-self.dt / self.trace)
+            self.x *= torch.exp(-self.dt / self.tc_trace)
             self.x.masked_fill_(self.s != 0, 1)
 
         if self.sum_input:
@@ -192,7 +192,7 @@ class McCullochPitts(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
+                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  thresh: Union[float, torch.Tensor] = 1.0) -> None:
         # language=rst
         """
@@ -201,11 +201,11 @@ class McCullochPitts(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param trace: Time constant of spike trace decay.
+        :param tc_trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param thresh: Spike threshold voltage.
         """
-        super().__init__(n, shape, traces, trace, sum_input)
+        super().__init__(n, shape, traces, tc_trace, sum_input)
 
         self.thresh = thresh  # Spike threshold voltage.
         self.v = torch.zeros(self.shape)  # Neuron voltages.
@@ -237,7 +237,7 @@ class IFNodes(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
+                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  thresh: Union[float, torch.Tensor] = -52.0, reset: Union[float, torch.Tensor] = -65.0,
                  refrac: Union[int, torch.Tensor] = 5, lbound: float = None) -> None:
         # language=rst
@@ -247,14 +247,14 @@ class IFNodes(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param trace: Time constant of spike trace decay.
+        :param tc_trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param thresh: Spike threshold voltage.
         :param reset: Post-spike reset voltage.
         :param refrac: Refractory (non-firing) period of the neuron.
         :param lbound: Lower bound of the voltage.
         """
-        super().__init__(n, shape, traces, trace, sum_input)
+        super().__init__(n, shape, traces, tc_trace, sum_input)
 
         self.reset = torch.tensor(reset)  # Post-spike reset voltage.
         self.thresh = torch.tensor(thresh)  # Spike threshold voltage.
@@ -308,10 +308,10 @@ class LIFNodes(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
+                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  thresh: Union[float, torch.Tensor] = -52.0, rest: Union[float, torch.Tensor] = -65.0,
                  reset: Union[float, torch.Tensor] = -65.0, refrac: Union[int, torch.Tensor] = 5,
-                 decay: Union[float, torch.Tensor] = 100.0, lbound: float = None) -> None:
+                 tc_decay: Union[float, torch.Tensor] = 100.0, lbound: float = None) -> None:
         # language=rst
         """
         Instantiates a layer of LIF neurons.
@@ -319,22 +319,22 @@ class LIFNodes(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param trace: Time constant of spike trace decay.
+        :param tc_trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param thresh: Spike threshold voltage.
         :param rest: Resting membrane voltage.
         :param reset: Post-spike reset voltage.
         :param refrac: Refractory (non-firing) period of the neuron.
-        :param decay: Time constant of neuron voltage decay.
+        :param tc_decay: Time constant of neuron voltage decay.
         :param lbound: Lower bound of the voltage.
         """
-        super().__init__(n, shape, traces, trace, sum_input)
+        super().__init__(n, shape, traces, tc_trace, sum_input)
 
         self.rest = torch.tensor(rest)  # Rest voltage.
         self.reset = torch.tensor(reset)  # Post-spike reset voltage.
         self.thresh = torch.tensor(thresh)  # Spike threshold voltage.
         self.refrac = torch.tensor(refrac)  # Post-spike refractory period.
-        self.decay = torch.tensor(decay)  # Time constant of neuron voltage decay.
+        self.tc_decay = torch.tensor(tc_decay)  # Time constant of neuron voltage decay.
         self.lbound = lbound  # Lower bound of voltage.
 
         self.v = self.rest * torch.ones(self.shape)  # Neuron voltages.
@@ -348,7 +348,7 @@ class LIFNodes(Nodes):
         :param x: Inputs to the layer.
         """
         # Decay voltages.
-        self.v = self.rest + torch.exp(-self.dt / self.decay) * (self.v - self.rest)
+        self.v = self.rest + torch.exp(-self.dt / self.tc_decay) * (self.v - self.rest)
 
         # Integrate inputs.
         self.v += (self.refrac_count == 0).float() * x
@@ -388,10 +388,10 @@ class CurrentLIFNodes(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
+                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  thresh: Union[float, torch.Tensor] = -52.0, rest: Union[float, torch.Tensor] = -65.0,
                  reset: Union[float, torch.Tensor] = -65.0, refrac: Union[int, torch.Tensor] = 5,
-                 decay: Union[float, torch.Tensor] = 100.0, i_decay: Union[float, torch.Tensor] = 2.0,
+                 tc_decay: Union[float, torch.Tensor] = 100.0, tc_i_decay: Union[float, torch.Tensor] = 2.0,
                  lbound: float = None) -> None:
         # language=rst
         """
@@ -399,24 +399,24 @@ class CurrentLIFNodes(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param trace: Time constant of spike trace decay.
+        :param tc_trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param thresh: Spike threshold voltage.
         :param rest: Resting membrane voltage.
         :param reset: Post-spike reset voltage.
         :param refrac: Refractory (non-firing) period of the neuron.
-        :param decay: Time constant of neuron voltage decay.
-        :param i_decay: Time constant of synaptic input current decay.
+        :param tc_decay: Time constant of neuron voltage decay.
+        :param tc_i_decay: Time constant of synaptic input current decay.
         :param lbound: Lower bound of the voltage.
         """
-        super().__init__(n, shape, traces, trace, sum_input)
+        super().__init__(n, shape, traces, tc_trace, sum_input)
 
         self.rest = torch.tensor(rest)  # Rest voltage.
         self.reset = torch.tensor(reset)  # Post-spike reset voltage.
         self.thresh = torch.tensor(thresh)  # Spike threshold voltage.
         self.refrac = torch.tensor(refrac)  # Post-spike refractory period.
-        self.decay = torch.tensor(decay)  # Time constant of neuron voltage decay.
-        self.i_decay = torch.tensor(i_decay)  # Time constant of synaptic input current decay.
+        self.tc_decay = torch.tensor(tc_decay)  # Time constant of neuron voltage decay.
+        self.tc_i_decay = torch.tensor(tc_i_decay)  # Time constant of synaptic input current decay.
         self.lbound = lbound  # Lower bound of voltage.
 
         self.v = self.rest * torch.ones(self.shape)  # Neuron voltages.
@@ -431,8 +431,8 @@ class CurrentLIFNodes(Nodes):
         :param x: Inputs to the layer.
         """
         # Decay voltages and current.
-        self.v = self.rest + torch.exp(-self.dt / self.decay) * (self.v - self.rest)
-        self.i *= torch.exp(-self.dt / self.i_decay)
+        self.v = self.rest + torch.exp(-self.dt / self.tc_decay) * (self.v - self.rest)
+        self.i *= torch.exp(-self.dt / self.tc_i_decay)
 
         # Decrement refractory counters.
         self.refrac_count = (self.refrac_count > 0).float() * (self.refrac_count - self.dt)
@@ -473,11 +473,11 @@ class AdaptiveLIFNodes(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
+                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  rest: Union[float, torch.Tensor] = -65.0, reset: Union[float, torch.Tensor] = -65.0,
                  thresh: Union[float, torch.Tensor] = -52.0, refrac: Union[int, torch.Tensor] = 5,
-                 decay: Union[float, torch.Tensor] = 100.0, theta_plus: Union[float, torch.Tensor] = 0.05,
-                 theta_decay: Union[float, torch.Tensor] = 1e7, lbound: float = None) -> None:
+                 tc_decay: Union[float, torch.Tensor] = 100.0, theta_plus: Union[float, torch.Tensor] = 0.05,
+                 tc_theta_decay: Union[float, torch.Tensor] = 1e7, lbound: float = None) -> None:
         # language=rst
         """
         Instantiates a layer of LIF neurons with adaptive firing thresholds.
@@ -485,26 +485,26 @@ class AdaptiveLIFNodes(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param trace: Time constant of spike trace decay.
+        :param tc_trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param rest: Resting membrane voltage.
         :param reset: Post-spike reset voltage.
         :param thresh: Spike threshold voltage.
         :param refrac: Refractory (non-firing) period of the neuron.
-        :param decay: Time constant of neuron voltage decay.
+        :param tc_decay: Time constant of neuron voltage decay.
         :param theta_plus: Voltage increase of threshold after spiking.
-        :param theta_decay: Time constant of adaptive threshold decay.
+        :param tc_theta_decay: Time constant of adaptive threshold decay.
         :param lbound: Lower bound of the voltage.
         """
-        super().__init__(n, shape, traces, trace, sum_input)
+        super().__init__(n, shape, traces, tc_trace, sum_input)
 
         self.rest = torch.tensor(rest)  # Rest voltage.
         self.reset = torch.tensor(reset)  # Post-spike reset voltage.
         self.thresh = torch.tensor(thresh)  # Spike threshold voltage.
         self.refrac = torch.tensor(refrac)  # Post-spike refractory period.
-        self.decay = torch.tensor(decay)  # Time constant of neuron voltage decay.
+        self.tc_decay = torch.tensor(tc_decay)  # Time constant of neuron voltage decay.
         self.theta_plus = torch.tensor(theta_plus)  # Constant threshold increase on spike.
-        self.theta_decay = torch.tensor(theta_decay)  # Time constant of adaptive threshold decay.
+        self.tc_theta_decay = torch.tensor(tc_theta_decay)  # Time constant of adaptive threshold decay.
         self.lbound = lbound  # Lower bound of voltage.
 
         self.v = self.rest * torch.ones(self.shape)  # Neuron voltages.
@@ -519,8 +519,8 @@ class AdaptiveLIFNodes(Nodes):
         :param x: Inputs to the layer.
         """
         # Decay voltages and adaptive thresholds.
-        self.v = self.rest + torch.exp(-self.dt / self.decay) * (self.v - self.rest)
-        self.theta *= torch.exp(-self.dt / self.theta_decay)
+        self.v = self.rest + torch.exp(-self.dt / self.tc_decay) * (self.v - self.rest)
+        self.theta *= torch.exp(-self.dt / self.tc_theta_decay)
 
         # Integrate inputs.
         self.v += (self.refrac_count == 0).float() * x
@@ -560,11 +560,11 @@ class DiehlAndCookNodes(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
+                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  thresh: Union[float, torch.Tensor] = -52.0, rest: Union[float, torch.Tensor] = -65.0,
                  reset: Union[float, torch.Tensor] = -65.0, refrac: Union[int, torch.Tensor] = 5,
-                 decay: Union[float, torch.Tensor] = 100.0, theta_plus: Union[float, torch.Tensor] = 0.05,
-                 theta_decay: Union[float, torch.Tensor] = 1e7, lbound: float = None,
+                 tc_decay: Union[float, torch.Tensor] = 100.0, theta_plus: Union[float, torch.Tensor] = 0.05,
+                 tc_theta_decay: Union[float, torch.Tensor] = 1e7, lbound: float = None,
                  one_spike: bool = True) -> None:
         # language=rst
         """
@@ -573,27 +573,27 @@ class DiehlAndCookNodes(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param trace: Time constant of spike trace decay.
+        :param tc_trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param thresh: Spike threshold voltage.
         :param rest: Resting membrane voltage.
         :param reset: Post-spike reset voltage.
         :param refrac: Refractory (non-firing) period of the neuron.
-        :param decay: Time constant of neuron voltage decay.
+        :param tc_decay: Time constant of neuron voltage decay.
         :param theta_plus: Voltage increase of threshold after spiking.
-        :param theta_decay: Time constant of adaptive threshold decay.
+        :param tc_theta_decay: Time constant of adaptive threshold decay.
         :param lbound: Lower bound of the voltage.
         :param one_spike: Whether to allow only one spike per timestep.
         """
-        super().__init__(n, shape, traces, trace, sum_input)
+        super().__init__(n, shape, traces, tc_trace, sum_input)
 
         self.rest = torch.tensor(rest)  # Rest voltage.
         self.reset = torch.tensor(reset)  # Post-spike reset voltage.
         self.thresh = torch.tensor(thresh)  # Spike threshold voltage.
         self.refrac = torch.tensor(refrac)  # Post-spike refractory period.
-        self.decay = torch.tensor(decay)  # Time constant of neuron voltage decay.
+        self.tc_decay = torch.tensor(tc_decay)  # Time constant of neuron voltage decay.
         self.theta_plus = torch.tensor(theta_plus)  # Constant threshold increase on spike.
-        self.theta_decay = torch.tensor(theta_decay)  # Time constant of adaptive threshold decay.
+        self.theta_decay = torch.tensor(tc_theta_decay)  # Time constant of adaptive threshold decay.
         self.lbound = lbound  # Lower bound of voltage.
         self.one_spike = one_spike  # One spike per timestep.
 
@@ -609,7 +609,7 @@ class DiehlAndCookNodes(Nodes):
         :param x: Inputs to the layer.
         """
         # Decay voltages and adaptive thresholds.
-        self.v = self.rest + torch.exp(-self.dt / self.decay) * (self.v - self.rest)
+        self.v = self.rest + torch.exp(-self.dt / self.tc_decay) * (self.v - self.rest)
         self.theta *= torch.exp(-self.dt / self.theta_decay)
 
         # Integrate inputs.
@@ -656,7 +656,7 @@ class IzhikevichNodes(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False, excitatory: float = 1,
+                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False, excitatory: float = 1,
                  thresh: Union[float, torch.Tensor] = 45.0, rest: Union[float, torch.Tensor] = -65.0,
                  lbound: float = None) -> None:
         # language=rst
@@ -666,14 +666,14 @@ class IzhikevichNodes(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param trace: Time constant of spike trace decay.
+        :param tc_trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param excitatory: Percent of excitatory (vs. inhibitory) neurons in the layer; in range ``[0, 1]``.
         :param thresh: Spike threshold voltage.
         :param rest: Resting membrane voltage.
         :param lbound: Lower bound of the voltage.
         """
-        super().__init__(n, shape, traces, trace, sum_input)
+        super().__init__(n, shape, traces, tc_trace, sum_input)
 
         self.rest = rest  # Rest voltage.
         self.thresh = thresh  # Spike threshold voltage.

--- a/bindsnet/network/nodes.py
+++ b/bindsnet/network/nodes.py
@@ -391,7 +391,7 @@ class CurrentLIFNodes(Nodes):
                  trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  thresh: Union[float, torch.Tensor] = -52.0, rest: Union[float, torch.Tensor] = -65.0,
                  reset: Union[float, torch.Tensor] = -65.0, refrac: Union[int, torch.Tensor] = 5,
-                 decay: Union[float, torch.Tensor] = 5e-2, tc_i_decay: Union[float, torch.Tensor] = 2.0,
+                 decay: Union[float, torch.Tensor] = 5e-2, i_decay: Union[float, torch.Tensor] = 2.0,
                  lbound: float = None) -> None:
         # language=rst
         """
@@ -406,7 +406,7 @@ class CurrentLIFNodes(Nodes):
         :param reset: Post-spike reset voltage.
         :param refrac: Refractory (non-firing) period of the neuron.
         :param decay: Time constant of neuron voltage decay.
-        :param tc_i_decay: Time constant of synaptic input current decay.
+        :param i_decay: Time constant of synaptic input current decay.
         :param lbound: Lower bound of the voltage.
         """
         super().__init__(n, shape, traces, trace, sum_input)
@@ -416,7 +416,7 @@ class CurrentLIFNodes(Nodes):
         self.thresh = torch.tensor(thresh)  # Spike threshold voltage.
         self.refrac = torch.tensor(refrac)  # Post-spike refractory period.
         self.decay = torch.tensor(decay)  # Time constant of neuron voltage decay.
-        self.tc_i_decay = torch.tensor(tc_i_decay)  # Time constant of synaptic input current decay.
+        self.i_decay = torch.tensor(i_decay)  # Time constant of synaptic input current decay.
         self.lbound = lbound  # Lower bound of voltage.
 
         self.v = self.rest * torch.ones(self.shape)  # Neuron voltages.
@@ -432,7 +432,7 @@ class CurrentLIFNodes(Nodes):
         """
         # Decay voltages and current.
         self.v = self.rest + torch.exp(-self.dt / self.decay) * (self.v - self.rest)
-        self.i *= torch.exp(-self.dt / self.tc_i_decay)
+        self.i *= torch.exp(-self.dt / self.i_decay)
 
         # Decrement refractory counters.
         self.refrac_count = (self.refrac_count > 0).float() * (self.refrac_count - self.dt)
@@ -477,7 +477,7 @@ class AdaptiveLIFNodes(Nodes):
                  rest: Union[float, torch.Tensor] = -65.0, reset: Union[float, torch.Tensor] = -65.0,
                  thresh: Union[float, torch.Tensor] = -52.0, refrac: Union[int, torch.Tensor] = 5,
                  decay: Union[float, torch.Tensor] = 5e-2, theta_plus: Union[float, torch.Tensor] = 0.05,
-                 tc_theta_decay: Union[float, torch.Tensor] = 1e7, lbound: float = None) -> None:
+                 theta_decay: Union[float, torch.Tensor] = 1e7, lbound: float = None) -> None:
         # language=rst
         """
         Instantiates a layer of LIF neurons with adaptive firing thresholds.
@@ -493,7 +493,7 @@ class AdaptiveLIFNodes(Nodes):
         :param refrac: Refractory (non-firing) period of the neuron.
         :param decay: Time constant of neuron voltage decay.
         :param theta_plus: Voltage increase of threshold after spiking.
-        :param tc_theta_decay: Time constant of adaptive threshold decay.
+        :param theta_decay: Time constant of adaptive threshold decay.
         :param lbound: Lower bound of the voltage.
         """
         super().__init__(n, shape, traces, trace, sum_input)
@@ -504,7 +504,7 @@ class AdaptiveLIFNodes(Nodes):
         self.refrac = torch.tensor(refrac)  # Post-spike refractory period.
         self.decay = torch.tensor(decay)  # Time constant of neuron voltage decay.
         self.theta_plus = torch.tensor(theta_plus)  # Constant threshold increase on spike.
-        self.tc_theta_decay = torch.tensor(tc_theta_decay)  # Time constant of adaptive threshold decay.
+        self.theta_decay = torch.tensor(theta_decay)  # Time constant of adaptive threshold decay.
         self.lbound = lbound  # Lower bound of voltage.
 
         self.v = self.rest * torch.ones(self.shape)  # Neuron voltages.
@@ -564,7 +564,7 @@ class DiehlAndCookNodes(Nodes):
                  thresh: Union[float, torch.Tensor] = -52.0, rest: Union[float, torch.Tensor] = -65.0,
                  reset: Union[float, torch.Tensor] = -65.0, refrac: Union[int, torch.Tensor] = 5,
                  decay: Union[float, torch.Tensor] = 5e-2, theta_plus: Union[float, torch.Tensor] = 0.05,
-                 tc_theta_decay: Union[float, torch.Tensor] = 1e7, lbound: float = None,
+                 theta_decay: Union[float, torch.Tensor] = 1e7, lbound: float = None,
                  one_spike: bool = True) -> None:
         # language=rst
         """
@@ -581,7 +581,7 @@ class DiehlAndCookNodes(Nodes):
         :param refrac: Refractory (non-firing) period of the neuron.
         :param decay: Time constant of neuron voltage decay.
         :param theta_plus: Voltage increase of threshold after spiking.
-        :param tc_theta_decay: Time constant of adaptive threshold decay.
+        :param theta_decay: Time constant of adaptive threshold decay.
         :param lbound: Lower bound of the voltage.
         :param one_spike: Whether to allow only one spike per timestep.
         """
@@ -593,7 +593,7 @@ class DiehlAndCookNodes(Nodes):
         self.refrac = torch.tensor(refrac)  # Post-spike refractory period.
         self.decay = torch.tensor(decay)  # Time constant of neuron voltage decay.
         self.theta_plus = torch.tensor(theta_plus)  # Constant threshold increase on spike.
-        self.theta_decay = torch.tensor(tc_theta_decay)  # Time constant of adaptive threshold decay.
+        self.theta_decay = torch.tensor(theta_decay)  # Time constant of adaptive threshold decay.
         self.lbound = lbound  # Lower bound of voltage.
         self.one_spike = one_spike  # One spike per timestep.
 

--- a/bindsnet/network/nodes.py
+++ b/bindsnet/network/nodes.py
@@ -391,7 +391,7 @@ class CurrentLIFNodes(Nodes):
                  trace_tc: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  thresh: Union[float, torch.Tensor] = -52.0, rest: Union[float, torch.Tensor] = -65.0,
                  reset: Union[float, torch.Tensor] = -65.0, refrac: Union[int, torch.Tensor] = 5,
-                 decay: Union[float, torch.Tensor] = 100.0, tc_i_decay: Union[float, torch.Tensor] = 2.0,
+                 decay: Union[float, torch.Tensor] = 5e-2, tc_i_decay: Union[float, torch.Tensor] = 2.0,
                  lbound: float = None) -> None:
         # language=rst
         """
@@ -476,7 +476,7 @@ class AdaptiveLIFNodes(Nodes):
                  trace_tc: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  rest: Union[float, torch.Tensor] = -65.0, reset: Union[float, torch.Tensor] = -65.0,
                  thresh: Union[float, torch.Tensor] = -52.0, refrac: Union[int, torch.Tensor] = 5,
-                 decay: Union[float, torch.Tensor] = 100.0, theta_plus: Union[float, torch.Tensor] = 0.05,
+                 decay: Union[float, torch.Tensor] = 5e-2, theta_plus: Union[float, torch.Tensor] = 0.05,
                  tc_theta_decay: Union[float, torch.Tensor] = 1e7, lbound: float = None) -> None:
         # language=rst
         """
@@ -563,7 +563,7 @@ class DiehlAndCookNodes(Nodes):
                  trace_tc: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  thresh: Union[float, torch.Tensor] = -52.0, rest: Union[float, torch.Tensor] = -65.0,
                  reset: Union[float, torch.Tensor] = -65.0, refrac: Union[int, torch.Tensor] = 5,
-                 decay: Union[float, torch.Tensor] = 100.0, theta_plus: Union[float, torch.Tensor] = 0.05,
+                 decay: Union[float, torch.Tensor] = 5e-2, theta_plus: Union[float, torch.Tensor] = 0.05,
                  tc_theta_decay: Union[float, torch.Tensor] = 1e7, lbound: float = None,
                  one_spike: bool = True) -> None:
         # language=rst

--- a/bindsnet/network/nodes.py
+++ b/bindsnet/network/nodes.py
@@ -13,7 +13,7 @@ class Nodes(ABC):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 trace_tc: Union[float, torch.Tensor] = 20.0, sum_input: bool = False) -> None:
+                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False) -> None:
         # language=rst
         """
         Abstract base class constructor.
@@ -21,7 +21,7 @@ class Nodes(ABC):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record decaying spike traces.
-        :param trace_tc: Time constant of spike trace decay.
+        :param trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         """
         super().__init__()
@@ -46,7 +46,7 @@ class Nodes(ABC):
 
         if self.traces:
             self.x = torch.zeros(self.shape)  # Firing traces.
-            self.trace_tc = torch.tensor(trace_tc)  # Time constant of spike trace decay.
+            self.trace = torch.tensor(trace)  # Time constant of spike trace decay.
 
         if self.sum_input:
             self.summed = torch.zeros(self.shape)  # Summed inputs.
@@ -64,7 +64,7 @@ class Nodes(ABC):
         """
         if self.traces:
             # Decay and set spike traces.
-            self.x -= self.dt * self.trace_tc * self.x
+            self.x -= self.dt * self.trace * self.x
             self.x.masked_fill_(self.s, 1)
 
         if self.sum_input:
@@ -103,7 +103,7 @@ class Input(Nodes, AbstractInput):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None,
-                 traces: bool = False, trace_tc: Union[float, torch.Tensor] = 20.0, sum_input: bool = False) -> None:
+                 traces: bool = False, trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False) -> None:
         # language=rst
         """
         Instantiates a layer of input neurons.
@@ -111,10 +111,10 @@ class Input(Nodes, AbstractInput):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record decaying spike traces.
-        :param trace_tc: Time constant of spike trace decay.
+        :param trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         """
-        super().__init__(n, shape, traces, trace_tc, sum_input)
+        super().__init__(n, shape, traces, trace, sum_input)
 
     def forward(self, x: torch.Tensor) -> None:
         # language=rst
@@ -142,7 +142,7 @@ class RealInput(Nodes, AbstractInput):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 trace_tc: Union[float, torch.Tensor] = 20.0, sum_input: bool = False) -> None:
+                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False) -> None:
         # language=rst
         """
         Instantiates a layer of input neurons.
@@ -150,10 +150,10 @@ class RealInput(Nodes, AbstractInput):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record decaying spike traces.
-        :param trace_tc: Time constant of spike trace decay.
+        :param trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         """
-        super().__init__(n, shape, traces, trace_tc, sum_input)
+        super().__init__(n, shape, traces, trace, sum_input)
 
         self.s = self.s.float()
 
@@ -169,7 +169,7 @@ class RealInput(Nodes, AbstractInput):
 
         if self.traces:
             # Decay and set spike traces.
-            self.x -= self.dt * self.trace_tc * self.x
+            self.x -= self.dt * self.trace * self.x
             self.x.masked_fill_(self.s != 0, 1)
 
         if self.sum_input:
@@ -192,7 +192,7 @@ class McCullochPitts(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 trace_tc: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
+                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  thresh: Union[float, torch.Tensor] = 1.0) -> None:
         # language=rst
         """
@@ -201,11 +201,11 @@ class McCullochPitts(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param trace_tc: Time constant of spike trace decay.
+        :param trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param thresh: Spike threshold voltage.
         """
-        super().__init__(n, shape, traces, trace_tc, sum_input)
+        super().__init__(n, shape, traces, trace, sum_input)
 
         self.thresh = thresh  # Spike threshold voltage.
         self.v = torch.zeros(self.shape)  # Neuron voltages.
@@ -237,7 +237,7 @@ class IFNodes(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 trace_tc: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
+                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  thresh: Union[float, torch.Tensor] = -52.0, reset: Union[float, torch.Tensor] = -65.0,
                  refrac: Union[int, torch.Tensor] = 5, lbound: float = None) -> None:
         # language=rst
@@ -247,14 +247,14 @@ class IFNodes(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param trace_tc: Time constant of spike trace decay.
+        :param trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param thresh: Spike threshold voltage.
         :param reset: Post-spike reset voltage.
         :param refrac: Refractory (non-firing) period of the neuron.
         :param lbound: Lower bound of the voltage.
         """
-        super().__init__(n, shape, traces, trace_tc, sum_input)
+        super().__init__(n, shape, traces, trace, sum_input)
 
         self.reset = torch.tensor(reset)  # Post-spike reset voltage.
         self.thresh = torch.tensor(thresh)  # Spike threshold voltage.
@@ -308,7 +308,7 @@ class LIFNodes(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 trace_tc: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
+                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  thresh: Union[float, torch.Tensor] = -52.0, rest: Union[float, torch.Tensor] = -65.0,
                  reset: Union[float, torch.Tensor] = -65.0, refrac: Union[int, torch.Tensor] = 5,
                  decay: Union[float, torch.Tensor] = 5e-2, lbound: float = None) -> None:
@@ -319,7 +319,7 @@ class LIFNodes(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param trace_tc: Time constant of spike trace decay.
+        :param trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param thresh: Spike threshold voltage.
         :param rest: Resting membrane voltage.
@@ -328,7 +328,7 @@ class LIFNodes(Nodes):
         :param decay: Time constant of neuron voltage decay.
         :param lbound: Lower bound of the voltage.
         """
-        super().__init__(n, shape, traces, trace_tc, sum_input)
+        super().__init__(n, shape, traces, trace, sum_input)
 
         self.rest = torch.tensor(rest)  # Rest voltage.
         self.reset = torch.tensor(reset)  # Post-spike reset voltage.
@@ -388,7 +388,7 @@ class CurrentLIFNodes(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 trace_tc: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
+                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  thresh: Union[float, torch.Tensor] = -52.0, rest: Union[float, torch.Tensor] = -65.0,
                  reset: Union[float, torch.Tensor] = -65.0, refrac: Union[int, torch.Tensor] = 5,
                  decay: Union[float, torch.Tensor] = 5e-2, tc_i_decay: Union[float, torch.Tensor] = 2.0,
@@ -399,7 +399,7 @@ class CurrentLIFNodes(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param trace_tc: Time constant of spike trace decay.
+        :param trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param thresh: Spike threshold voltage.
         :param rest: Resting membrane voltage.
@@ -409,7 +409,7 @@ class CurrentLIFNodes(Nodes):
         :param tc_i_decay: Time constant of synaptic input current decay.
         :param lbound: Lower bound of the voltage.
         """
-        super().__init__(n, shape, traces, trace_tc, sum_input)
+        super().__init__(n, shape, traces, trace, sum_input)
 
         self.rest = torch.tensor(rest)  # Rest voltage.
         self.reset = torch.tensor(reset)  # Post-spike reset voltage.
@@ -473,7 +473,7 @@ class AdaptiveLIFNodes(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 trace_tc: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
+                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  rest: Union[float, torch.Tensor] = -65.0, reset: Union[float, torch.Tensor] = -65.0,
                  thresh: Union[float, torch.Tensor] = -52.0, refrac: Union[int, torch.Tensor] = 5,
                  decay: Union[float, torch.Tensor] = 5e-2, theta_plus: Union[float, torch.Tensor] = 0.05,
@@ -485,7 +485,7 @@ class AdaptiveLIFNodes(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param trace_tc: Time constant of spike trace decay.
+        :param trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param rest: Resting membrane voltage.
         :param reset: Post-spike reset voltage.
@@ -496,7 +496,7 @@ class AdaptiveLIFNodes(Nodes):
         :param tc_theta_decay: Time constant of adaptive threshold decay.
         :param lbound: Lower bound of the voltage.
         """
-        super().__init__(n, shape, traces, trace_tc, sum_input)
+        super().__init__(n, shape, traces, trace, sum_input)
 
         self.rest = torch.tensor(rest)  # Rest voltage.
         self.reset = torch.tensor(reset)  # Post-spike reset voltage.
@@ -560,7 +560,7 @@ class DiehlAndCookNodes(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 trace_tc: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
+                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  thresh: Union[float, torch.Tensor] = -52.0, rest: Union[float, torch.Tensor] = -65.0,
                  reset: Union[float, torch.Tensor] = -65.0, refrac: Union[int, torch.Tensor] = 5,
                  decay: Union[float, torch.Tensor] = 5e-2, theta_plus: Union[float, torch.Tensor] = 0.05,
@@ -573,7 +573,7 @@ class DiehlAndCookNodes(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param trace_tc: Time constant of spike trace decay.
+        :param trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param thresh: Spike threshold voltage.
         :param rest: Resting membrane voltage.
@@ -585,7 +585,7 @@ class DiehlAndCookNodes(Nodes):
         :param lbound: Lower bound of the voltage.
         :param one_spike: Whether to allow only one spike per timestep.
         """
-        super().__init__(n, shape, traces, trace_tc, sum_input)
+        super().__init__(n, shape, traces, trace, sum_input)
 
         self.rest = torch.tensor(rest)  # Rest voltage.
         self.reset = torch.tensor(reset)  # Post-spike reset voltage.
@@ -656,7 +656,7 @@ class IzhikevichNodes(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 trace_tc: Union[float, torch.Tensor] = 20.0, sum_input: bool = False, excitatory: float = 1,
+                 trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False, excitatory: float = 1,
                  thresh: Union[float, torch.Tensor] = 45.0, rest: Union[float, torch.Tensor] = -65.0,
                  lbound: float = None) -> None:
         # language=rst
@@ -666,14 +666,14 @@ class IzhikevichNodes(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param trace_tc: Time constant of spike trace decay.
+        :param trace: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param excitatory: Percent of excitatory (vs. inhibitory) neurons in the layer; in range ``[0, 1]``.
         :param thresh: Spike threshold voltage.
         :param rest: Resting membrane voltage.
         :param lbound: Lower bound of the voltage.
         """
-        super().__init__(n, shape, traces, trace_tc, sum_input)
+        super().__init__(n, shape, traces, trace, sum_input)
 
         self.rest = rest  # Rest voltage.
         self.thresh = thresh  # Spike threshold voltage.

--- a/bindsnet/network/nodes.py
+++ b/bindsnet/network/nodes.py
@@ -64,7 +64,7 @@ class Nodes(ABC):
         """
         if self.traces:
             # Decay and set spike traces.
-            self.x *= torch.exp(-self.dt / self.trace_tc)
+            self.x -= self.dt * self.trace_tc * self.x
             self.x.masked_fill_(self.s, 1)
 
         if self.sum_input:
@@ -169,7 +169,7 @@ class RealInput(Nodes, AbstractInput):
 
         if self.traces:
             # Decay and set spike traces.
-            self.x *= torch.exp(-self.dt / self.trace_tc)
+            self.x -= self.dt * self.trace_tc * self.x
             self.x.masked_fill_(self.s != 0, 1)
 
         if self.sum_input:
@@ -519,8 +519,8 @@ class AdaptiveLIFNodes(Nodes):
         :param x: Inputs to the layer.
         """
         # Decay voltages and adaptive thresholds.
-        self.v = self.rest + torch.exp(-self.dt / self.decay) * (self.v - self.rest)
-        self.theta *= torch.exp(-self.dt / self.tc_theta_decay)
+        self.v -= self.dt * self.decay * (self.v - self.rest)
+        self.theta -= self.dt * self.theta_decay * self.theta
 
         # Integrate inputs.
         self.v += (self.refrac_count == 0).float() * x
@@ -609,8 +609,8 @@ class DiehlAndCookNodes(Nodes):
         :param x: Inputs to the layer.
         """
         # Decay voltages and adaptive thresholds.
-        self.v = self.rest + torch.exp(-self.dt / self.decay) * (self.v - self.rest)
-        self.theta *= torch.exp(-self.dt / self.theta_decay)
+        self.v -= self.dt * self.decay * (self.v - self.rest)
+        self.theta -= self.dt * self.theta_decay * self.theta
 
         # Integrate inputs.
         self.v += (self.refrac_count == 0).float() * x

--- a/bindsnet/network/nodes.py
+++ b/bindsnet/network/nodes.py
@@ -13,7 +13,7 @@ class Nodes(ABC):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False) -> None:
+                 trace_tc: Union[float, torch.Tensor] = 20.0, sum_input: bool = False) -> None:
         # language=rst
         """
         Abstract base class constructor.
@@ -21,7 +21,7 @@ class Nodes(ABC):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record decaying spike traces.
-        :param tc_trace: Time constant of spike trace decay.
+        :param trace_tc: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         """
         super().__init__()
@@ -46,7 +46,7 @@ class Nodes(ABC):
 
         if self.traces:
             self.x = torch.zeros(self.shape)  # Firing traces.
-            self.tc_trace = torch.tensor(tc_trace)  # Time constant of spike trace decay.
+            self.trace_tc = torch.tensor(trace_tc)  # Time constant of spike trace decay.
 
         if self.sum_input:
             self.summed = torch.zeros(self.shape)  # Summed inputs.
@@ -64,7 +64,7 @@ class Nodes(ABC):
         """
         if self.traces:
             # Decay and set spike traces.
-            self.x *= torch.exp(-self.dt / self.tc_trace)
+            self.x *= torch.exp(-self.dt / self.trace_tc)
             self.x.masked_fill_(self.s, 1)
 
         if self.sum_input:
@@ -103,7 +103,7 @@ class Input(Nodes, AbstractInput):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None,
-                 traces: bool = False, tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False) -> None:
+                 traces: bool = False, trace_tc: Union[float, torch.Tensor] = 20.0, sum_input: bool = False) -> None:
         # language=rst
         """
         Instantiates a layer of input neurons.
@@ -111,10 +111,10 @@ class Input(Nodes, AbstractInput):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record decaying spike traces.
-        :param tc_trace: Time constant of spike trace decay.
+        :param trace_tc: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         """
-        super().__init__(n, shape, traces, tc_trace, sum_input)
+        super().__init__(n, shape, traces, trace_tc, sum_input)
 
     def forward(self, x: torch.Tensor) -> None:
         # language=rst
@@ -142,7 +142,7 @@ class RealInput(Nodes, AbstractInput):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False) -> None:
+                 trace_tc: Union[float, torch.Tensor] = 20.0, sum_input: bool = False) -> None:
         # language=rst
         """
         Instantiates a layer of input neurons.
@@ -150,10 +150,10 @@ class RealInput(Nodes, AbstractInput):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record decaying spike traces.
-        :param tc_trace: Time constant of spike trace decay.
+        :param trace_tc: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         """
-        super().__init__(n, shape, traces, tc_trace, sum_input)
+        super().__init__(n, shape, traces, trace_tc, sum_input)
 
         self.s = self.s.float()
 
@@ -169,7 +169,7 @@ class RealInput(Nodes, AbstractInput):
 
         if self.traces:
             # Decay and set spike traces.
-            self.x *= torch.exp(-self.dt / self.tc_trace)
+            self.x *= torch.exp(-self.dt / self.trace_tc)
             self.x.masked_fill_(self.s != 0, 1)
 
         if self.sum_input:
@@ -192,7 +192,7 @@ class McCullochPitts(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
+                 trace_tc: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  thresh: Union[float, torch.Tensor] = 1.0) -> None:
         # language=rst
         """
@@ -201,11 +201,11 @@ class McCullochPitts(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param tc_trace: Time constant of spike trace decay.
+        :param trace_tc: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param thresh: Spike threshold voltage.
         """
-        super().__init__(n, shape, traces, tc_trace, sum_input)
+        super().__init__(n, shape, traces, trace_tc, sum_input)
 
         self.thresh = thresh  # Spike threshold voltage.
         self.v = torch.zeros(self.shape)  # Neuron voltages.
@@ -237,7 +237,7 @@ class IFNodes(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
+                 trace_tc: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  thresh: Union[float, torch.Tensor] = -52.0, reset: Union[float, torch.Tensor] = -65.0,
                  refrac: Union[int, torch.Tensor] = 5, lbound: float = None) -> None:
         # language=rst
@@ -247,14 +247,14 @@ class IFNodes(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param tc_trace: Time constant of spike trace decay.
+        :param trace_tc: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param thresh: Spike threshold voltage.
         :param reset: Post-spike reset voltage.
         :param refrac: Refractory (non-firing) period of the neuron.
         :param lbound: Lower bound of the voltage.
         """
-        super().__init__(n, shape, traces, tc_trace, sum_input)
+        super().__init__(n, shape, traces, trace_tc, sum_input)
 
         self.reset = torch.tensor(reset)  # Post-spike reset voltage.
         self.thresh = torch.tensor(thresh)  # Spike threshold voltage.
@@ -308,10 +308,10 @@ class LIFNodes(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
+                 trace_tc: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  thresh: Union[float, torch.Tensor] = -52.0, rest: Union[float, torch.Tensor] = -65.0,
                  reset: Union[float, torch.Tensor] = -65.0, refrac: Union[int, torch.Tensor] = 5,
-                 tc_decay: Union[float, torch.Tensor] = 100.0, lbound: float = None) -> None:
+                 decay: Union[float, torch.Tensor] = 5e-2, lbound: float = None) -> None:
         # language=rst
         """
         Instantiates a layer of LIF neurons.
@@ -319,22 +319,22 @@ class LIFNodes(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param tc_trace: Time constant of spike trace decay.
+        :param trace_tc: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param thresh: Spike threshold voltage.
         :param rest: Resting membrane voltage.
         :param reset: Post-spike reset voltage.
         :param refrac: Refractory (non-firing) period of the neuron.
-        :param tc_decay: Time constant of neuron voltage decay.
+        :param decay: Time constant of neuron voltage decay.
         :param lbound: Lower bound of the voltage.
         """
-        super().__init__(n, shape, traces, tc_trace, sum_input)
+        super().__init__(n, shape, traces, trace_tc, sum_input)
 
         self.rest = torch.tensor(rest)  # Rest voltage.
         self.reset = torch.tensor(reset)  # Post-spike reset voltage.
         self.thresh = torch.tensor(thresh)  # Spike threshold voltage.
         self.refrac = torch.tensor(refrac)  # Post-spike refractory period.
-        self.tc_decay = torch.tensor(tc_decay)  # Time constant of neuron voltage decay.
+        self.decay = torch.tensor(decay)  # Time constant of neuron voltage decay.
         self.lbound = lbound  # Lower bound of voltage.
 
         self.v = self.rest * torch.ones(self.shape)  # Neuron voltages.
@@ -348,7 +348,7 @@ class LIFNodes(Nodes):
         :param x: Inputs to the layer.
         """
         # Decay voltages.
-        self.v = self.rest + torch.exp(-self.dt / self.tc_decay) * (self.v - self.rest)
+        self.v = self.rest + torch.exp(-self.dt / self.decay) * (self.v - self.rest)
 
         # Integrate inputs.
         self.v += (self.refrac_count == 0).float() * x
@@ -388,10 +388,10 @@ class CurrentLIFNodes(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
+                 trace_tc: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  thresh: Union[float, torch.Tensor] = -52.0, rest: Union[float, torch.Tensor] = -65.0,
                  reset: Union[float, torch.Tensor] = -65.0, refrac: Union[int, torch.Tensor] = 5,
-                 tc_decay: Union[float, torch.Tensor] = 100.0, tc_i_decay: Union[float, torch.Tensor] = 2.0,
+                 decay: Union[float, torch.Tensor] = 100.0, tc_i_decay: Union[float, torch.Tensor] = 2.0,
                  lbound: float = None) -> None:
         # language=rst
         """
@@ -399,23 +399,23 @@ class CurrentLIFNodes(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param tc_trace: Time constant of spike trace decay.
+        :param trace_tc: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param thresh: Spike threshold voltage.
         :param rest: Resting membrane voltage.
         :param reset: Post-spike reset voltage.
         :param refrac: Refractory (non-firing) period of the neuron.
-        :param tc_decay: Time constant of neuron voltage decay.
+        :param decay: Time constant of neuron voltage decay.
         :param tc_i_decay: Time constant of synaptic input current decay.
         :param lbound: Lower bound of the voltage.
         """
-        super().__init__(n, shape, traces, tc_trace, sum_input)
+        super().__init__(n, shape, traces, trace_tc, sum_input)
 
         self.rest = torch.tensor(rest)  # Rest voltage.
         self.reset = torch.tensor(reset)  # Post-spike reset voltage.
         self.thresh = torch.tensor(thresh)  # Spike threshold voltage.
         self.refrac = torch.tensor(refrac)  # Post-spike refractory period.
-        self.tc_decay = torch.tensor(tc_decay)  # Time constant of neuron voltage decay.
+        self.decay = torch.tensor(decay)  # Time constant of neuron voltage decay.
         self.tc_i_decay = torch.tensor(tc_i_decay)  # Time constant of synaptic input current decay.
         self.lbound = lbound  # Lower bound of voltage.
 
@@ -431,7 +431,7 @@ class CurrentLIFNodes(Nodes):
         :param x: Inputs to the layer.
         """
         # Decay voltages and current.
-        self.v = self.rest + torch.exp(-self.dt / self.tc_decay) * (self.v - self.rest)
+        self.v = self.rest + torch.exp(-self.dt / self.decay) * (self.v - self.rest)
         self.i *= torch.exp(-self.dt / self.tc_i_decay)
 
         # Decrement refractory counters.
@@ -473,10 +473,10 @@ class AdaptiveLIFNodes(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
+                 trace_tc: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  rest: Union[float, torch.Tensor] = -65.0, reset: Union[float, torch.Tensor] = -65.0,
                  thresh: Union[float, torch.Tensor] = -52.0, refrac: Union[int, torch.Tensor] = 5,
-                 tc_decay: Union[float, torch.Tensor] = 100.0, theta_plus: Union[float, torch.Tensor] = 0.05,
+                 decay: Union[float, torch.Tensor] = 100.0, theta_plus: Union[float, torch.Tensor] = 0.05,
                  tc_theta_decay: Union[float, torch.Tensor] = 1e7, lbound: float = None) -> None:
         # language=rst
         """
@@ -485,24 +485,24 @@ class AdaptiveLIFNodes(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param tc_trace: Time constant of spike trace decay.
+        :param trace_tc: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param rest: Resting membrane voltage.
         :param reset: Post-spike reset voltage.
         :param thresh: Spike threshold voltage.
         :param refrac: Refractory (non-firing) period of the neuron.
-        :param tc_decay: Time constant of neuron voltage decay.
+        :param decay: Time constant of neuron voltage decay.
         :param theta_plus: Voltage increase of threshold after spiking.
         :param tc_theta_decay: Time constant of adaptive threshold decay.
         :param lbound: Lower bound of the voltage.
         """
-        super().__init__(n, shape, traces, tc_trace, sum_input)
+        super().__init__(n, shape, traces, trace_tc, sum_input)
 
         self.rest = torch.tensor(rest)  # Rest voltage.
         self.reset = torch.tensor(reset)  # Post-spike reset voltage.
         self.thresh = torch.tensor(thresh)  # Spike threshold voltage.
         self.refrac = torch.tensor(refrac)  # Post-spike refractory period.
-        self.tc_decay = torch.tensor(tc_decay)  # Time constant of neuron voltage decay.
+        self.decay = torch.tensor(decay)  # Time constant of neuron voltage decay.
         self.theta_plus = torch.tensor(theta_plus)  # Constant threshold increase on spike.
         self.tc_theta_decay = torch.tensor(tc_theta_decay)  # Time constant of adaptive threshold decay.
         self.lbound = lbound  # Lower bound of voltage.
@@ -519,7 +519,7 @@ class AdaptiveLIFNodes(Nodes):
         :param x: Inputs to the layer.
         """
         # Decay voltages and adaptive thresholds.
-        self.v = self.rest + torch.exp(-self.dt / self.tc_decay) * (self.v - self.rest)
+        self.v = self.rest + torch.exp(-self.dt / self.decay) * (self.v - self.rest)
         self.theta *= torch.exp(-self.dt / self.tc_theta_decay)
 
         # Integrate inputs.
@@ -560,10 +560,10 @@ class DiehlAndCookNodes(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
+                 trace_tc: Union[float, torch.Tensor] = 20.0, sum_input: bool = False,
                  thresh: Union[float, torch.Tensor] = -52.0, rest: Union[float, torch.Tensor] = -65.0,
                  reset: Union[float, torch.Tensor] = -65.0, refrac: Union[int, torch.Tensor] = 5,
-                 tc_decay: Union[float, torch.Tensor] = 100.0, theta_plus: Union[float, torch.Tensor] = 0.05,
+                 decay: Union[float, torch.Tensor] = 100.0, theta_plus: Union[float, torch.Tensor] = 0.05,
                  tc_theta_decay: Union[float, torch.Tensor] = 1e7, lbound: float = None,
                  one_spike: bool = True) -> None:
         # language=rst
@@ -573,25 +573,25 @@ class DiehlAndCookNodes(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param tc_trace: Time constant of spike trace decay.
+        :param trace_tc: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param thresh: Spike threshold voltage.
         :param rest: Resting membrane voltage.
         :param reset: Post-spike reset voltage.
         :param refrac: Refractory (non-firing) period of the neuron.
-        :param tc_decay: Time constant of neuron voltage decay.
+        :param decay: Time constant of neuron voltage decay.
         :param theta_plus: Voltage increase of threshold after spiking.
         :param tc_theta_decay: Time constant of adaptive threshold decay.
         :param lbound: Lower bound of the voltage.
         :param one_spike: Whether to allow only one spike per timestep.
         """
-        super().__init__(n, shape, traces, tc_trace, sum_input)
+        super().__init__(n, shape, traces, trace_tc, sum_input)
 
         self.rest = torch.tensor(rest)  # Rest voltage.
         self.reset = torch.tensor(reset)  # Post-spike reset voltage.
         self.thresh = torch.tensor(thresh)  # Spike threshold voltage.
         self.refrac = torch.tensor(refrac)  # Post-spike refractory period.
-        self.tc_decay = torch.tensor(tc_decay)  # Time constant of neuron voltage decay.
+        self.decay = torch.tensor(decay)  # Time constant of neuron voltage decay.
         self.theta_plus = torch.tensor(theta_plus)  # Constant threshold increase on spike.
         self.theta_decay = torch.tensor(tc_theta_decay)  # Time constant of adaptive threshold decay.
         self.lbound = lbound  # Lower bound of voltage.
@@ -609,7 +609,7 @@ class DiehlAndCookNodes(Nodes):
         :param x: Inputs to the layer.
         """
         # Decay voltages and adaptive thresholds.
-        self.v = self.rest + torch.exp(-self.dt / self.tc_decay) * (self.v - self.rest)
+        self.v = self.rest + torch.exp(-self.dt / self.decay) * (self.v - self.rest)
         self.theta *= torch.exp(-self.dt / self.theta_decay)
 
         # Integrate inputs.
@@ -656,7 +656,7 @@ class IzhikevichNodes(Nodes):
     """
 
     def __init__(self, n: Optional[int] = None, shape: Optional[Iterable[int]] = None, traces: bool = False,
-                 tc_trace: Union[float, torch.Tensor] = 20.0, sum_input: bool = False, excitatory: float = 1,
+                 trace_tc: Union[float, torch.Tensor] = 20.0, sum_input: bool = False, excitatory: float = 1,
                  thresh: Union[float, torch.Tensor] = 45.0, rest: Union[float, torch.Tensor] = -65.0,
                  lbound: float = None) -> None:
         # language=rst
@@ -666,14 +666,14 @@ class IzhikevichNodes(Nodes):
         :param n: The number of neurons in the layer.
         :param shape: The dimensionality of the layer.
         :param traces: Whether to record spike traces.
-        :param tc_trace: Time constant of spike trace decay.
+        :param trace_tc: Time constant of spike trace decay.
         :param sum_input: Whether to sum all inputs.
         :param excitatory: Percent of excitatory (vs. inhibitory) neurons in the layer; in range ``[0, 1]``.
         :param thresh: Spike threshold voltage.
         :param rest: Resting membrane voltage.
         :param lbound: Lower bound of the voltage.
         """
-        super().__init__(n, shape, traces, tc_trace, sum_input)
+        super().__init__(n, shape, traces, trace_tc, sum_input)
 
         self.rest = rest  # Rest voltage.
         self.thresh = thresh  # Spike threshold voltage.

--- a/test/network/test_nodes.py
+++ b/test/network/test_nodes.py
@@ -20,10 +20,10 @@ class TestNodes:
                              AdaptiveLIFNodes]:
                     assert (layer.v == layer.rest * torch.ones(n)).all()
 
-                layer = nodes(n, traces=True, tc_trace=1e5)
+                layer = nodes(n, traces=True, trace=1e-5)
 
                 assert layer.n == n;
-                assert layer.tc_trace == 1e5
+                assert layer.trace == 1e-5
                 assert (layer.s.float() == torch.zeros(n)).all()
                 assert (layer.x == torch.zeros(n)).all()
                 assert (layer.x == torch.zeros(n)).all()
@@ -34,12 +34,12 @@ class TestNodes:
 
         for nodes in [LIFNodes, AdaptiveLIFNodes]:
             for n in [1, 100, 10000]:
-                layer = nodes(n, rest=0.0, reset=-10.0, thresh=10.0, refrac=3, tc_decay=1.5e3)
+                layer = nodes(n, rest=0.0, reset=-10.0, thresh=10.0, refrac=3, decay=7e-4)
 
                 assert layer.rest == 0.0;
                 assert layer.reset == -10.0;
                 assert layer.thresh == 10.0
                 assert layer.refrac == 3;
-                assert layer.tc_decay == 1.5e3
+                assert layer.decay == 7e-4
                 assert (layer.s.float() == torch.zeros(n)).all()
                 assert (layer.v == layer.rest * torch.ones(n)).all()


### PR DESCRIPTION
Reverting changes made by @Huizerd.
1. The neuron decay was not intuitive, small decay constant should influence by small changes and not vice versa.
2. revert the neuron update and remove the exp from the activation functions, its make the simulation slower and don't add any value to the activation function  
3. default values break backward compatibility.
4. rename trace_tc to trace. No need to the prefix tc_ 