### PR TITLE
Fixed voltage update; code cleanup on eth_mnist.py

### DIFF
--- a/bindsnet/network/nodes.py
+++ b/bindsnet/network/nodes.py
@@ -387,7 +387,7 @@ class LIFNodes(Nodes):
         :param x: Inputs to the layer.
         """
         # Decay voltages.
-        self.v -= self.decay * (self.v - self.rest)
+        self.v = self.decay * (self.v - self.rest) + self.rest
 
         # Integrate inputs.
         self.v += (self.refrac_count == 0).float() * x
@@ -480,7 +480,7 @@ class CurrentLIFNodes(Nodes):
         :param x: Inputs to the layer.
         """
         # Decay voltages and current.
-        self.v -= self.decay * (self.v - self.rest)
+        self.v = self.decay * (self.v - self.rest) + self.rest
         self.i *= self.i_decay
 
         # Decrement refractory counters.
@@ -579,7 +579,7 @@ class AdaptiveLIFNodes(Nodes):
         :param x: Inputs to the layer.
         """
         # Decay voltages and adaptive thresholds.
-        self.v -= self.decay * (self.v - self.rest)
+        self.v = self.decay * (self.v - self.rest) + self.rest
         self.theta *= self.theta_decay
 
         # Integrate inputs.
@@ -680,7 +680,7 @@ class DiehlAndCookNodes(Nodes):
         :param x: Inputs to the layer.
         """
         # Decay voltages and adaptive thresholds.
-        self.v -= self.decay * (self.v - self.rest)
+        self.v = self.decay * (self.v - self.rest) + self.rest
         self.theta *= self.theta_decay
 
         # Integrate inputs.

--- a/bindsnet/network/nodes.py
+++ b/bindsnet/network/nodes.py
@@ -387,7 +387,7 @@ class LIFNodes(Nodes):
         :param x: Inputs to the layer.
         """
         # Decay voltages.
-        self.v = self.rest + self.decay * (self.v - self.rest)
+        self.v -= self.decay * (self.v - self.rest)
 
         # Integrate inputs.
         self.v += (self.refrac_count == 0).float() * x
@@ -480,7 +480,7 @@ class CurrentLIFNodes(Nodes):
         :param x: Inputs to the layer.
         """
         # Decay voltages and current.
-        self.v = self.rest + self.decay * (self.v - self.rest)
+        self.v -= self.decay * (self.v - self.rest)
         self.i *= self.i_decay
 
         # Decrement refractory counters.
@@ -579,7 +579,7 @@ class AdaptiveLIFNodes(Nodes):
         :param x: Inputs to the layer.
         """
         # Decay voltages and adaptive thresholds.
-        self.v = self.rest + self.decay * (self.v - self.rest)
+        self.v -= self.decay * (self.v - self.rest)
         self.theta *= self.theta_decay
 
         # Integrate inputs.
@@ -680,7 +680,7 @@ class DiehlAndCookNodes(Nodes):
         :param x: Inputs to the layer.
         """
         # Decay voltages and adaptive thresholds.
-        self.v = self.rest + self.decay * (self.v - self.rest)
+        self.v -= self.decay * (self.v - self.rest)
         self.theta *= self.theta_decay
 
         # Integrate inputs.

--- a/examples/mnist/eth_mnist.py
+++ b/examples/mnist/eth_mnist.py
@@ -95,6 +95,13 @@ for layer in set(network.layers) - {'X'}:
     spikes[layer] = Monitor(network.layers[layer], state_vars=['s'], time=time)
     network.add_monitor(spikes[layer], name='%s_spikes' % layer)
 
+inpt_ims, inpt_axes = None, None
+spike_ims, spike_axes = None, None
+weights_im = None
+assigns_im = None
+perf_ax = None
+voltage_axes, voltage_ims = None, None
+
 # Train the network.
 print('\nBegin training.\n')
 start = t()
@@ -146,25 +153,19 @@ for i in range(n_train):
         input_exc_weights = network.connections[('X', 'Ae')].w
         square_weights = get_square_weights(input_exc_weights.view(784, n_neurons), n_sqrt, 28)
         square_assignments = get_square_assignments(assignments, n_sqrt)
+        spikes_ = {layer: spikes[layer].get('s') for layer in spikes}
         voltages = {'Ae': exc_voltages, 'Ai': inh_voltages}
 
-        if i == 0:
-            inpt_axes, inpt_ims = plot_input(images[i].view(28, 28), inpt, label=labels[i])
-            spike_ims, spike_axes = plot_spikes({layer: spikes[layer].get('s') for layer in spikes})
-            weights_im = plot_weights(square_weights)
-            assigns_im = plot_assignments(square_assignments)
-            perf_ax = plot_performance(accuracy)
-            voltage_ims, voltage_axes = plot_voltages(voltages)
-
-        else:
-            inpt_axes, inpt_ims = plot_input(images[i].view(28, 28), inpt, label=labels[i], axes=inpt_axes,
-                                             ims=inpt_ims)
-            spike_ims, spike_axes = plot_spikes({layer: spikes[layer].get('s') for layer in spikes},
-                                                ims=spike_ims, axes=spike_axes)
-            weights_im = plot_weights(square_weights, im=weights_im)
-            assigns_im = plot_assignments(square_assignments, im=assigns_im)
-            perf_ax = plot_performance(accuracy, ax=perf_ax)
-            voltage_ims, voltage_axes = plot_voltages(voltages, ims=voltage_ims, axes=voltage_axes)
+        inpt_axes, inpt_ims = plot_input(
+            images[i].view(28, 28), inpt, label=labels[i], axes=inpt_axes, ims=inpt_ims
+        )
+        spike_ims, spike_axes = plot_spikes(
+            spikes_, ims=spike_ims, axes=spike_axes
+        )
+        weights_im = plot_weights(square_weights, im=weights_im)
+        assigns_im = plot_assignments(square_assignments, im=assigns_im)
+        perf_ax = plot_performance(accuracy, ax=perf_ax)
+        voltage_ims, voltage_axes = plot_voltages(voltages, ims=voltage_ims, axes=voltage_axes, plot_type='line')
 
         plt.pause(1e-8)
 


### PR DESCRIPTION
The voltage decay update

`self.v = self.decay * (self.v - self.rest) + self.rest`

where `self.decay = torch.exp(-self.dt / self.tc_decay)` was correct after all. This is just the solution (after one `self.dt`) of a exponential decay equation, decaying to `self.rest`. 

This fixes the `eth_mnist.py` example (#236):

```
python eth_mnist.py --update_interval 100
Loading training images from serialized object file.

Loading training labels from serialized object file.


Begin training.

Progress: 0 / 60000 (0.0000 seconds)
Progress: 10 / 60000 (2.0086 seconds)
Progress: 20 / 60000 (2.0318 seconds)
Progress: 30 / 60000 (2.0657 seconds)
Progress: 40 / 60000 (2.5359 seconds)
Progress: 50 / 60000 (2.5048 seconds)
Progress: 60 / 60000 (2.5677 seconds)
Progress: 70 / 60000 (2.5803 seconds)
Progress: 80 / 60000 (2.5304 seconds)
Progress: 90 / 60000 (2.5658 seconds)
Progress: 100 / 60000 (2.5165 seconds)

All activity accuracy: 11.00 (last), 11.00 (average), 11.00 (best)
Proportion weighting accuracy: 11.00 (last), 11.00 (average), 11.00 (best)

Progress: 110 / 60000 (2.5691 seconds)
Progress: 120 / 60000 (2.5376 seconds)
Progress: 130 / 60000 (2.5309 seconds)
Progress: 140 / 60000 (2.5361 seconds)
Progress: 150 / 60000 (2.5374 seconds)
Progress: 160 / 60000 (2.5303 seconds)
Progress: 170 / 60000 (2.5409 seconds)
Progress: 180 / 60000 (2.5347 seconds)
Progress: 190 / 60000 (2.5978 seconds)
Progress: 200 / 60000 (2.5410 seconds)

All activity accuracy: 59.00 (last), 35.00 (average), 59.00 (best)
Proportion weighting accuracy: 59.00 (last), 35.00 (average), 59.00 (best)

Progress: 210 / 60000 (2.5234 seconds)
Progress: 220 / 60000 (2.5467 seconds)
Progress: 230 / 60000 (2.5531 seconds)
Progress: 240 / 60000 (2.5303 seconds)
Progress: 250 / 60000 (2.5588 seconds)
Progress: 260 / 60000 (2.5201 seconds)
Progress: 270 / 60000 (2.5627 seconds)
Progress: 280 / 60000 (2.5329 seconds)
Progress: 290 / 60000 (2.5258 seconds)
Progress: 300 / 60000 (2.5392 seconds)

All activity accuracy: 62.00 (last), 44.00 (average), 62.00 (best)
Proportion weighting accuracy: 65.00 (last), 45.00 (average), 65.00 (best)

Progress: 310 / 60000 (2.5991 seconds)
Progress: 320 / 60000 (2.5379 seconds)
Progress: 330 / 60000 (2.5663 seconds)
Progress: 340 / 60000 (2.5413 seconds)
Progress: 350 / 60000 (2.5299 seconds)
Progress: 360 / 60000 (2.5006 seconds)
Progress: 370 / 60000 (2.5624 seconds)
Progress: 380 / 60000 (2.5447 seconds)
Progress: 390 / 60000 (2.5392 seconds)
Progress: 400 / 60000 (2.7253 seconds)

All activity accuracy: 69.00 (last), 50.25 (average), 69.00 (best)
Proportion weighting accuracy: 69.00 (last), 51.00 (average), 69.00 (best)

Progress: 410 / 60000 (2.7042 seconds)
Progress: 420 / 60000 (2.6397 seconds)
Progress: 430 / 60000 (2.8096 seconds)
Progress: 440 / 60000 (2.5960 seconds)
Progress: 450 / 60000 (2.5673 seconds)
Progress: 460 / 60000 (2.5900 seconds)
Progress: 470 / 60000 (2.6103 seconds)
Progress: 480 / 60000 (2.5534 seconds)
Progress: 490 / 60000 (2.5722 seconds)
Progress: 500 / 60000 (2.5649 seconds)

All activity accuracy: 60.00 (last), 52.20 (average), 69.00 (best)
Proportion weighting accuracy: 60.00 (last), 52.80 (average), 69.00 (best)

Progress: 510 / 60000 (2.5946 seconds)
Progress: 520 / 60000 (2.5681 seconds)
Progress: 530 / 60000 (2.9740 seconds)
Progress: 540 / 60000 (2.8328 seconds)
Progress: 550 / 60000 (2.7192 seconds)
Progress: 560 / 60000 (3.0178 seconds)
Progress: 570 / 60000 (2.8704 seconds)
Progress: 580 / 60000 (3.1157 seconds)
Progress: 590 / 60000 (2.6855 seconds)
Progress: 600 / 60000 (2.6592 seconds)

All activity accuracy: 62.00 (last), 53.83 (average), 69.00 (best)
Proportion weighting accuracy: 65.00 (last), 54.83 (average), 69.00 (best)

Progress: 610 / 60000 (2.6580 seconds)
Progress: 620 / 60000 (2.6112 seconds)
Progress: 630 / 60000 (2.6996 seconds)
Progress: 640 / 60000 (2.7083 seconds)
Progress: 650 / 60000 (2.6550 seconds)
Progress: 660 / 60000 (2.6496 seconds)
Progress: 670 / 60000 (2.6033 seconds)
Progress: 680 / 60000 (2.6581 seconds)
Progress: 690 / 60000 (2.6025 seconds)
Progress: 700 / 60000 (2.5786 seconds)

All activity accuracy: 64.00 (last), 55.29 (average), 69.00 (best)
Proportion weighting accuracy: 66.00 (last), 56.43 (average), 69.00 (best)

Progress: 710 / 60000 (3.2735 seconds)
Progress: 720 / 60000 (2.8266 seconds)
Progress: 730 / 60000 (2.8710 seconds)
Progress: 740 / 60000 (2.9978 seconds)
Progress: 750 / 60000 (2.9453 seconds)
Progress: 760 / 60000 (3.1116 seconds)
Progress: 770 / 60000 (2.7463 seconds)
Progress: 780 / 60000 (2.9810 seconds)
Progress: 790 / 60000 (2.5780 seconds)
Progress: 800 / 60000 (2.6660 seconds)

All activity accuracy: 62.00 (last), 56.12 (average), 69.00 (best)
Proportion weighting accuracy: 65.00 (last), 57.50 (average), 69.00 (best)

Progress: 810 / 60000 (2.5765 seconds)
Progress: 820 / 60000 (2.5483 seconds)
Progress: 830 / 60000 (2.6041 seconds)
Progress: 840 / 60000 (2.5451 seconds)
Progress: 850 / 60000 (2.5199 seconds)
Progress: 860 / 60000 (2.5346 seconds)
Progress: 870 / 60000 (2.5542 seconds)
Progress: 880 / 60000 (2.6163 seconds)
Progress: 890 / 60000 (2.6615 seconds)
Progress: 900 / 60000 (2.5734 seconds)

All activity accuracy: 61.00 (last), 56.67 (average), 69.00 (best)
Proportion weighting accuracy: 62.00 (last), 58.00 (average), 69.00 (best)

Progress: 910 / 60000 (2.6635 seconds)
Progress: 920 / 60000 (2.6226 seconds)
Progress: 930 / 60000 (2.6032 seconds)
Progress: 940 / 60000 (2.5388 seconds)
Progress: 950 / 60000 (2.6027 seconds)
Progress: 960 / 60000 (2.6100 seconds)
Progress: 970 / 60000 (2.6318 seconds)
Progress: 980 / 60000 (2.6206 seconds)
Progress: 990 / 60000 (2.5815 seconds)
Progress: 1000 / 60000 (2.6479 seconds)

All activity accuracy: 67.00 (last), 57.70 (average), 69.00 (best)
Proportion weighting accuracy: 69.00 (last), 59.10 (average), 69.00 (best)
```