### PR TITLE
Disables adaptive threshold when network.learning = False; removing unused code.

### DIFF
--- a/bindsnet/network/__init__.py
+++ b/bindsnet/network/__init__.py
@@ -21,7 +21,7 @@ def load(file_name: str, map_location: str = "cpu", learning: bool = None) -> "N
     :param learning: Whether to load with learning enabled. Default loads value from disk.
     """
     network = torch.load(open(file_name, "rb"), map_location=map_location)
-    if learning is not None and "learning" in vars(network):
+    if learning is not None:
         network.learning = learning
 
     return network
@@ -101,6 +101,7 @@ class Network:
         self.connections = {}
         self.monitors = {}
         self.learning = learning
+
         if reward_fn is not None:
             self.reward_fn = reward_fn()
         else:

--- a/bindsnet/network/nodes.py
+++ b/bindsnet/network/nodes.py
@@ -666,7 +666,8 @@ class AdaptiveLIFNodes(Nodes):
         """
         # Decay voltages and adaptive thresholds.
         self.v = self.decay * (self.v - self.rest) + self.rest
-        self.theta *= self.theta_decay
+        if self.network.learning:
+            self.theta *= self.theta_decay
 
         # Integrate inputs.
         self.v += (self.refrac_count == 0).float() * x
@@ -682,7 +683,8 @@ class AdaptiveLIFNodes(Nodes):
         # Refractoriness, voltage reset, and adaptive thresholds.
         self.refrac_count.masked_fill_(self.s, self.refrac)
         self.v.masked_fill_(self.s, self.reset)
-        self.theta += self.theta_plus * self.s.float()
+        if self.network.learning:
+            self.theta += self.theta_plus * self.s.float()
 
         # voltage clipping to lowerbound
         if self.lbound is not None:
@@ -787,7 +789,8 @@ class DiehlAndCookNodes(Nodes):
         """
         # Decay voltages and adaptive thresholds.
         self.v = self.decay * (self.v - self.rest) + self.rest
-        self.theta *= self.theta_decay
+        if self.network.learning:
+            self.theta *= self.theta_decay
 
         # Integrate inputs.
         self.v += (self.refrac_count == 0).float() * x
@@ -803,7 +806,8 @@ class DiehlAndCookNodes(Nodes):
         # Refractoriness, voltage reset, and adaptive thresholds.
         self.refrac_count.masked_fill_(self.s, self.refrac)
         self.v.masked_fill_(self.s, self.reset)
-        self.theta += self.theta_plus * self.s.float()
+        if self.network.learning:
+            self.theta += self.theta_plus * self.s.float()
 
         # Choose only a single neuron to spike.
         if self.one_spike:

--- a/bindsnet/network/topology.py
+++ b/bindsnet/network/topology.py
@@ -41,10 +41,6 @@ class AbstractConnection(ABC):
         :param ByteTensor norm_by_max: Normalize the weight of a neuron by its max weight.
         :param ByteTensor norm_by_max_with_shadow_weights: Normalize the weight of a neuron by its max weight by
                                                                 original weights
-        :param ByteTensor sign: True: to keep the connection positive.
-                                False: keep the connection negative.
-                                None: Ignore, connection can change signs on the fly
-                                ----NOT IMPLEMENTED YET ----
         """
         self.w = None
         self.dt = None
@@ -67,7 +63,6 @@ class AbstractConnection(ABC):
         self.norm_by_max_from_shadow_weights = kwargs.get(
             "norm_by_max_from_shadow_weights", False
         )
-        self.sign = kwargs.get("sign", None)
 
         if self.update_rule is None:
             self.update_rule = NoOp
@@ -159,10 +154,6 @@ class Connection(AbstractConnection):
         :param ByteTensor norm_by_max: Normalize the weight of a neuron by its max weight.
         :param ByteTensor norm_by_max_with_shadow_weights: Normalize the weight of a neuron by its max weight by
                                                            original weights.
-        :param ByteTensor sign: True: to keep the connection positive.
-                                False: keep the connection negative.
-                                None: Ignore, connection can change signs on the fly.
-                                ----NOT IMPLEMENTED YET ----
         """
         super().__init__(source, target, nu, weight_decay, **kwargs)
 

--- a/examples/mnist/minimal_mnist.py
+++ b/examples/mnist/minimal_mnist.py
@@ -17,7 +17,7 @@ network = DiehlAndCook2015(
 
 # Specify dataset
 mnist = MNIST(
-    PoissonEncoder(time=50.0, dt=1.0),
+    PoissonEncoder(time=50, dt=1.0),
     None,
     "../../data/MNIST",
     download=True,


### PR DESCRIPTION
Now, there is no need to manually set theta_decay and theta_plus to zero when testing a network with a layer with adaptive thresholds.