### PR TITLE
fixed docs in netwrok.run()

### DIFF
--- a/bindsnet/encoding/encodings.py
+++ b/bindsnet/encoding/encodings.py
@@ -68,7 +68,7 @@ def bernoulli(
     assert (datum >= 0).all(), "Inputs must be non-negative"
 
     shape, size = datum.shape, datum.numel()
-    datum = datum.view(-1)
+    datum = datum.flatten()
 
     if time is not None:
         time = int(time / dt)
@@ -105,7 +105,7 @@ def poisson(datum: torch.Tensor, time: int, dt: float = 1.0, **kwargs) -> torch.
 
     # Get shape and size of data.
     shape, size = datum.shape, datum.numel()
-    datum = datum.view(-1)
+    datum = datum.flatten()
     time = int(time / dt)
 
     # Compute firing rates in seconds as function of data intensity,
@@ -147,7 +147,7 @@ def rank_order(
     assert (datum >= 0).all(), "Inputs must be non-negative"
 
     shape, size = datum.shape, datum.numel()
-    datum = datum.view(-1)
+    datum = datum.flatten()
     time = int(time / dt)
 
     # Create spike times in order of decreasing intensity.

--- a/bindsnet/network/network.py
+++ b/bindsnet/network/network.py
@@ -242,7 +242,7 @@ class Network(torch.nn.Module):
         Simulate network for given inputs and time.
 
         :param inputs: Dictionary of ``Tensor``s of shape ``[time, *input_shape]`` or
-                      ``[batch_size, time, *input_shape]``.
+                      ``[time, batch_size, *input_shape]``.
         :param time: Simulation time.
         :param one_step: Whether to run the network in "feed-forward" mode, where inputs
             propagate all the way through the network in a single simulation time step.

--- a/bindsnet/pipeline/environment_pipeline.py
+++ b/bindsnet/pipeline/environment_pipeline.py
@@ -163,7 +163,7 @@ class EnvironmentPipeline(BasePipeline):
 
         # Place the observations into the inputs.
         obs_shape = [1] * len(obs.shape[1:])
-        inpts = {k: obs.repeat(self.time, *obs_shape) for k in self.inpts}
+        inputs = {k: obs.repeat(self.time, *obs_shape) for k in self.inputs}
 
         # Run the network on the spike train-encoded inputs.
         self.network.run(inputs=inputs, time=self.time, reward=reward, **kwargs)

--- a/test/conversion/test_conversion.py
+++ b/test/conversion/test_conversion.py
@@ -26,7 +26,7 @@ class FullyConnectedNetwork(nn.Module):
 
 def test_conversion():
     ann = FullyConnectedNetwork()
-    snn = ann_to_snn(ann, input_shape=(28, 28))
+    snn = ann_to_snn(ann, input_shape=(784,))
 
 
 def main():


### PR DESCRIPTION
`torch.flatten()` was added in v0.4.1. I changed this because I experienced some error with `.view(-1)` but now I cannot reproduce it, so it can be neglected if you wish.
The main fix is in `network.run()` docs and typo in `inpts`.

Update.
Also, I forgot to add a line in `network.run()` that `time` axis is obtained from `encoding` module, cause it was not obvious for me.